### PR TITLE
automatically generate crd documentation and add to a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Generate and Release CRD Docs
+
+on:
+  push:
+    tags:
+      - '*'  # Trigger on tag pushes
+
+jobs:
+  generate-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed for creating releases and uploading assets
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Install crd-ref-docs tool
+        run: go install github.com/elastic/crd-ref-docs@latest
+
+      - name: Generate CRD documentation
+        run: |
+          $HOME/go/bin/crd-ref-docs \
+            --renderer=markdown \
+            --source-path=./api \
+            --config=./config/crd/crd-doc-config.yaml \
+            --output-path=./config/crd/crd-docs.md
+
+      - name: Create Release and Generate Notes
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./config/crd/crd-docs.md
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version-file: 'go.mod' 
 
       - name: Install crd-ref-docs tool
         run: go install github.com/elastic/crd-ref-docs@latest

--- a/config/crd/crd-doc-config.yaml
+++ b/config/crd/crd-doc-config.yaml
@@ -1,8 +1,7 @@
 processor:
   ignoreTypes:
-    # - "List$"
-    # - "Status$"
+    # whole types can be ignored, please see https://github.com/elastic/crd-ref-docs?tab=readme-ov-file#configuration 
   ignoreFields:
-    # - "status$"
+    # concrete fields can be ignored, please see https://github.com/elastic/crd-ref-docs?tab=readme-ov-file#configuration 
 render:
   kubernetesVersion: 1.32

--- a/config/crd/crd-doc-config.yaml
+++ b/config/crd/crd-doc-config.yaml
@@ -1,0 +1,8 @@
+processor:
+  ignoreTypes:
+    # - "List$"
+    # - "Status$"
+  ignoreFields:
+    # - "status$"
+render:
+  kubernetesVersion: 1.32


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Automatically generates CRD documentation and attaches it as an asset to a release on a tag push
- Example release with the generated CRD docs can be found on [my fork ](https://github.com/Disper/infrastructure-manager/releases/tag/1.28.8). Manual verification can be done e.g. on a fork after merging this workflow and pushing a new tag `env KIM_VERSION=1.28.9 bash -c 'git tag -a $KIM_VERSION -m "$KIM_VERSION" && git push {YOUR_REMOTE} $KIM_VERSION'`
- ...

**Related issue(s)**
#1005 
