### PR TITLE
Exclude golangci-lint from allcheckspassed GH action

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@842d68ae85b27d7b15d133af95683a40eba477a1
         with:
+          checks_exclude: 'golangci-lint'
           delay: '3'
           retries: '30'
           polling_interval: '1'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/infrastructure-manager
 
-go 1.24.7
+go 1.25.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Temporaily fix for the problem with  `golangci-lint-action` latest [release 8.0](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0) not compatible with Golang 1.25.x.

```
  Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
  Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
  
  Error: golangci-lint exit with code 3
  Ran golangci-lint in 100ms
```

With this change we can migrate to Golang 1.25.x and we can merge all PR using new version of Golang even though golangci-lint-action fails. 

We can restore previous workflow after  `golangci-lint-action` is released with Go 1.25