### PR TITLE
Refactor token expiration handling, create an default boundaries

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ import (
 
 	registrycachecontroller "github.com/kyma-project/infrastructure-manager/internal/controller/registrycache"
 	"github.com/kyma-project/infrastructure-manager/internal/registrycache"
+	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/token"
 	registrycacheapi "github.com/kyma-project/kim-snatch/api/v1beta1"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -222,6 +223,12 @@ func main() {
 	auditLogDataMap, err := loadAuditLogDataMap(config.ConverterConfig.AuditLog.TenantConfigPath)
 	if err != nil {
 		setupLog.Error(err, "invalid audit log tenant configuration")
+		os.Exit(1)
+	}
+
+	_, err = token.ValidateTokenExpirationTime(config.ConverterConfig.Kubernetes.KubeApiServer.MaxTokenExpiration)
+	if err != nil {
+		setupLog.Error(err, "invalid token expiration format in converter configuration")
 		os.Exit(1)
 	}
 

--- a/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
@@ -3,11 +3,14 @@ package fsm
 import (
 	"context"
 	"fmt"
+
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/go-logr/logr"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/log_level"
 	gardener_shoot "github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender"
+	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/token"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/structuredauth"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -78,6 +81,18 @@ func sFnCreateShoot(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl
 			msgFailedToConfigureAuditlogs)
 	}
 
+	timeBoundaries, err := token.ValidateTokenExpirationTime(m.ConverterConfig.Kubernetes.KubeApiServer.MaxTokenExpiration)
+	if err != nil {
+		m.log.Error(err, "Failed to convert token expiration time")
+		m.Metrics.IncRuntimeFSMStopCounter()
+		return updateStatePendingWithErrorAndStop(
+			&s.instance,
+			imv1.ConditionTypeRuntimeProvisioned,
+			imv1.ConditionReasonConversionError,
+			fmt.Sprintf("Token expiration time, invalid format %v", err))
+	}
+	logTokenExpirationInfo(m.log, timeBoundaries)
+
 	shoot, err := convertCreate(&s.instance, gardener_shoot.CreateOpts{
 		ConverterConfig:       m.ConverterConfig,
 		AuditLogData:          data,
@@ -133,4 +148,16 @@ func convertCreate(instance *imv1.Runtime, opts gardener_shoot.CreateOpts) (gard
 	}
 
 	return newShoot, nil
+}
+
+func logTokenExpirationInfo(log logr.Logger, tokenLiveTime token.TimeBoundaries) {
+	if tokenLiveTime.NotDefined {
+		log.Info("Token expiration time is not defined, defaulting to minimum of 30 days.", "severity", "warning")
+	}
+	if tokenLiveTime.TooShort {
+		log.Info("Token expiration below allowed minimum, using minimum of 30 days.", "severity", "warning")
+	}
+	if tokenLiveTime.TooLong {
+		log.Info("Token expiration above allowed maximum, using maximum of 90 days.", "severity", "warning")
+	}
 }

--- a/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
@@ -81,16 +81,7 @@ func sFnCreateShoot(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl
 			msgFailedToConfigureAuditlogs)
 	}
 
-	timeBoundaries, err := token.ValidateTokenExpirationTime(m.ConverterConfig.Kubernetes.KubeApiServer.MaxTokenExpiration)
-	if err != nil {
-		m.log.Error(err, "Failed to convert token expiration time")
-		m.Metrics.IncRuntimeFSMStopCounter()
-		return updateStatePendingWithErrorAndStop(
-			&s.instance,
-			imv1.ConditionTypeRuntimeProvisioned,
-			imv1.ConditionReasonConversionError,
-			fmt.Sprintf("Token expiration time, invalid format %v", err))
-	}
+	timeBoundaries, _ := token.ValidateTokenExpirationTime(m.ConverterConfig.Kubernetes.KubeApiServer.MaxTokenExpiration)
 	logTokenExpirationInfo(m.log, timeBoundaries)
 
 	shoot, err := convertCreate(&s.instance, gardener_shoot.CreateOpts{

--- a/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
@@ -62,16 +62,7 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 			msgFailedStructuredConfigMap)
 	}
 
-	timeBoundaries, err := token.ValidateTokenExpirationTime(m.ConverterConfig.Kubernetes.KubeApiServer.MaxTokenExpiration)
-	if err != nil {
-		m.log.Error(err, "Failed to convert token expiration time")
-		m.Metrics.IncRuntimeFSMStopCounter()
-		return updateStatePendingWithErrorAndStop(
-			&s.instance,
-			imv1.ConditionTypeRuntimeProvisioned,
-			imv1.ConditionReasonConversionError,
-			fmt.Sprintf("Token expiration time, invalid format %v", err))
-	}
+	timeBoundaries, _ := token.ValidateTokenExpirationTime(m.ConverterConfig.Kubernetes.KubeApiServer.MaxTokenExpiration)
 	logTokenExpirationInfo(m.log, timeBoundaries)
 
 	// NOTE: In the future we want to pass the whole shoot object here
@@ -85,7 +76,6 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 		Resources:             s.shoot.Spec.Resources,
 		InfrastructureConfig:  s.shoot.Spec.Provider.InfrastructureConfig,
 		ControlPlaneConfig:    s.shoot.Spec.Provider.ControlPlaneConfig,
-		Log:                   ptr.To(m.log),
 	})
 
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Config struct {
@@ -32,7 +31,7 @@ type DNSConfig struct {
 }
 
 type KubernetesConfig struct {
-	KubeApiServer                       KubeApiServer `json:"kubeApiServer" validate:"required"`
+	KubeApiServer                       KubeApiServer `json:"kubeApiServer"`
 	DefaultVersion                      string        `json:"defaultVersion" validate:"required"`
 	EnableKubernetesVersionAutoUpdate   bool          `json:"enableKubernetesVersionAutoUpdate"`
 	EnableMachineImageVersionAutoUpdate bool          `json:"enableMachineImageVersionVersionAutoUpdate"`
@@ -78,8 +77,7 @@ type MachineImageConfig struct {
 }
 
 type KubeApiServer struct {
-	ExtendTokenExpiration *bool           `json:"extendTokenExpiration" validate:"required"`
-	MaxTokenExpiration    metav1.Duration `json:"maxTokenExpiration" validate:"required"`
+	MaxTokenExpiration string `json:"maxTokenExpiration"`
 }
 
 type TolerationsConfig map[string][]gardener.Toleration

--- a/pkg/gardener/shoot/converter.go
+++ b/pkg/gardener/shoot/converter.go
@@ -98,7 +98,7 @@ func NewConverterCreate(opts CreateOpts) Converter {
 				opts.AuditLogData))
 	}
 
-	extendersForCreate = append(extendersForCreate, token.NewExpirationTimeExtender(opts.Kubernetes.KubeApiServer.MaxTokenExpiration, opts.Kubernetes.KubeApiServer.ExtendTokenExpiration))
+	extendersForCreate = append(extendersForCreate, token.NewExpirationTimeExtender(opts.Kubernetes.KubeApiServer.MaxTokenExpiration))
 
 	return newConverter(opts.ConverterConfig, extendersForCreate...)
 }
@@ -128,7 +128,7 @@ func NewConverterPatch(opts PatchOpts) Converter {
 			auditlogs.NewAuditlogExtenderForPatch(opts.AuditLog.PolicyConfigMapName))
 	}
 
-	extendersForPatch = append(extendersForPatch, token.NewExpirationTimeExtender(opts.Kubernetes.KubeApiServer.MaxTokenExpiration, opts.Kubernetes.KubeApiServer.ExtendTokenExpiration))
+	extendersForPatch = append(extendersForPatch, token.NewExpirationTimeExtender(opts.Kubernetes.KubeApiServer.MaxTokenExpiration))
 
 	return newConverter(opts.ConverterConfig, extendersForPatch...)
 }

--- a/pkg/gardener/shoot/converter.go
+++ b/pkg/gardener/shoot/converter.go
@@ -3,7 +3,6 @@ package shoot
 import (
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/maintenance"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/provider"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/restrictions"
@@ -67,7 +66,6 @@ type PatchOpts struct {
 	Resources            []gardener.NamedResourceReference
 	InfrastructureConfig *runtime.RawExtension
 	ControlPlaneConfig   *runtime.RawExtension
-	Log                  *logr.Logger
 }
 
 func NewConverterCreate(opts CreateOpts) Converter {

--- a/pkg/gardener/shoot/converter_test.go
+++ b/pkg/gardener/shoot/converter_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/auditlogs"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/extensions"
@@ -560,8 +559,7 @@ var testReader io.Reader = strings.NewReader(
 		"usernamePrefix": "-"
 		},
 		"kubeApiServer": {
-			"extendTokenExpiration": true,
-            "maxTokenExpiration": "2592000s"
+            "maxTokenExpiration": "721h"
 		}
   },
   "dns": {
@@ -622,8 +620,7 @@ func Test_ConverterConfig_Load_OK(t *testing.T) {
 					UsernamePrefix: "-",
 				},
 				KubeApiServer: config.KubeApiServer{
-					MaxTokenExpiration:    v1.Duration{Duration: 2592000 * time.Second},
-					ExtendTokenExpiration: ptr.To(true),
+					MaxTokenExpiration: "721h",
 				},
 			},
 			DNS: config.DNSConfig{

--- a/pkg/gardener/shoot/extender/token/tokenExpiration.go
+++ b/pkg/gardener/shoot/extender/token/tokenExpiration.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const upperBound = 7776000 // 90 days in seconds
-const lowerBound = 2592000 // 30 days in seconds
+const upperBound = 90 * 24 * time.Hour // 90 days in seconds
+const lowerBound = 30 * 24 * time.Hour // 30 days in seconds
 type TimeBoundaries struct {
 	TooShort   bool
 	TooLong    bool
@@ -45,15 +45,14 @@ func ValidateTokenExpirationTime(maxTokenExpiration string) (TimeBoundaries, err
 		return TimeBoundaries{NotDefined: true}, nil
 	}
 
-	parsedTokenExpirationTime, err := time.ParseDuration(maxTokenExpiration)
+	parsed, err := time.ParseDuration(maxTokenExpiration)
 	if err != nil {
 		return TimeBoundaries{}, err
 	}
 
-	seconds := parsedTokenExpirationTime.Seconds()
 	return TimeBoundaries{
-		TooShort:   seconds < lowerBound,
-		TooLong:    seconds > upperBound,
+		TooShort:   parsed < lowerBound,
+		TooLong:    parsed > upperBound,
 		NotDefined: false,
 	}, nil
 }

--- a/pkg/gardener/shoot/extender/token/tokenExpiration.go
+++ b/pkg/gardener/shoot/extender/token/tokenExpiration.go
@@ -1,12 +1,23 @@
 package token
 
 import (
+	"time"
+
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
-func NewExpirationTimeExtender(maxTokenExpiration metav1.Duration, extendTokenExpiration *bool) func(_ imv1.Runtime, shoot *gardener.Shoot) error {
+const upperBound = 7776000 // 90 days in seconds
+const lowerBound = 2592000 // 30 days in seconds
+type TimeBoundaries struct {
+	TooShort   bool
+	TooLong    bool
+	NotDefined bool
+}
+
+func NewExpirationTimeExtender(maxTokenExpiration string) func(_ imv1.Runtime, shoot *gardener.Shoot) error {
 	return func(_ imv1.Runtime, shoot *gardener.Shoot) error {
 		if shoot.Spec.Kubernetes.KubeAPIServer == nil {
 			shoot.Spec.Kubernetes.KubeAPIServer = &gardener.KubeAPIServerConfig{}
@@ -14,8 +25,47 @@ func NewExpirationTimeExtender(maxTokenExpiration metav1.Duration, extendTokenEx
 		if shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig == nil {
 			shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &gardener.ServiceAccountConfig{}
 		}
-		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration = &maxTokenExpiration
-		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.ExtendTokenExpiration = extendTokenExpiration
+		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.ExtendTokenExpiration = ptr.To(false)
+
+		result, err := ValidateTokenExpirationTime(maxTokenExpiration)
+		if err != nil {
+			return err
+		}
+
+		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration = &metav1.Duration{
+			Duration: determineTokenExpiration(result, maxTokenExpiration),
+		}
+
 		return nil
+	}
+}
+
+func ValidateTokenExpirationTime(maxTokenExpiration string) (TimeBoundaries, error) {
+	if maxTokenExpiration == "" {
+		return TimeBoundaries{NotDefined: true}, nil
+	}
+
+	parsedTokenExpirationTime, err := time.ParseDuration(maxTokenExpiration)
+	if err != nil {
+		return TimeBoundaries{}, err
+	}
+
+	seconds := parsedTokenExpirationTime.Seconds()
+	return TimeBoundaries{
+		TooShort:   seconds < lowerBound,
+		TooLong:    seconds > upperBound,
+		NotDefined: false,
+	}, nil
+}
+
+func determineTokenExpiration(result TimeBoundaries, maxTokenExpiration string) time.Duration {
+	switch {
+	case result.TooShort || result.NotDefined:
+		return lowerBound
+	case result.TooLong:
+		return upperBound
+	default:
+		parsedDuration, _ := time.ParseDuration(maxTokenExpiration)
+		return parsedDuration
 	}
 }

--- a/pkg/gardener/shoot/extender/token/tokenExpiration_test.go
+++ b/pkg/gardener/shoot/extender/token/tokenExpiration_test.go
@@ -8,27 +8,57 @@ import (
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestNewExpirationTimeExtender(t *testing.T) {
-	t.Run("Should create an token expiration config for Shoot", func(t *testing.T) {
-		// given
-		maxTokenExpirationTime := &metav1.Duration{
-			Duration: time.Second * 2592001, // 30 days and 1 second
-		}
-		extendTokenExpiration := ptr.To(true)
+	for _, testCase := range []struct {
+		name                       string
+		providedTokenExpiration    string
+		expectedExpirationDuration time.Duration
+		error                      bool
+	}{
+		{
+			name:                       "Should set token expiration to 30 days if provided token time is shorter than 30 days",
+			providedTokenExpiration:    "24h",
+			expectedExpirationDuration: lowerBound,
+		},
+		{
+			name:                       "Should set token expiration to 90 days if provided token time is longer than 90 days",
+			providedTokenExpiration:    "2400h",
+			expectedExpirationDuration: upperBound,
+		},
+		{
+			name:                       "Should set user specific token expiration time if it is between boundaries 30 days and 90 days",
+			providedTokenExpiration:    "1200h", // 50 days
+			expectedExpirationDuration: 1200 * time.Hour,
+		},
+		{
+			name:                       "Should set default token expiration time (30 days) if token time is not provided",
+			providedTokenExpiration:    "",
+			expectedExpirationDuration: lowerBound,
+		},
+		{
+			name:                    "Should return an error if it was problem during parsing time format",
+			providedTokenExpiration: "30d",
+			error:                   true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// given
+			extender := NewExpirationTimeExtender(testCase.providedTokenExpiration)
+			shoot := testutils.FixEmptyGardenerShoot("test", "dev")
 
-		extender := NewExpirationTimeExtender(*maxTokenExpirationTime, extendTokenExpiration)
-		shoot := testutils.FixEmptyGardenerShoot("test", "dev")
+			// when
+			err := extender(imv1.Runtime{}, &shoot)
 
-		// when
-		err := extender(imv1.Runtime{}, &shoot)
-
-		// then
-        require.NoError(t, err)
-	assert.Equal(t, *maxTokenExpirationTime, *shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration)
-		assert.Equal(t, *extendTokenExpiration, *shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.ExtendTokenExpiration)
-	})
+			// then
+			if testCase.error {
+				require.Error(t, err)
+				assert.Nil(t, shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedExpirationDuration, shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration)
+		})
+	}
 }


### PR DESCRIPTION
**Description**
Refactor the logic of setting `maxTokenExpiration`, and create default token time boundaries.

Changes proposed in this pull request:


Field `MaxTokenExpiration` is configurable with the converter config file, and the allowed token lifetime duration will be between >= 30 days and <= 90 days.
 - if value < 30 days, we log an warning and set it to 30 days in the code.
 - if value is > 90 days, we log a warning and set to 90 days in the code.
 - if value is missing, we log a warning and set it to 30 days

Field `ExtendTokenExpiration` is always set to `false` and it is not configuralbe

