### PR TITLE
Replace badgen.net with badgers.space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![REUSE status](https://api.reuse.software/badge/github.com/kyma-project/infrastructure-manager)](https://api.reuse.software/info/github.com/kyma-project/infrastructure-manager)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kyma-project/infrastructure-manager)](https://goreportcard.com/report/github.com/kyma-project/infrastructure-manager)
-[![unit tests](https://badgen.net/github/checks/kyma-project/kyma-infrastructure-manager/main/unit-tests)](https://github.com/kyma-project/kyma-infrastructure-manager/actions/workflows/run-tests.yaml)
+[![unit tests](https://badgers.space/github/checks/kyma-project/kyma-infrastructure-manager/main/unit-tests)](https://github.com/kyma-project/kyma-infrastructure-manager/actions/workflows/run-tests.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/kyma-project/kyma-infrastructure-manager/badge.svg?branch=main)](https://coveralls.io/github/kyma-project/kyma-infrastructure-manager?branch=main)
-[![golangci lint](https://badgen.net/github/checks/kyma-project/kyma-infrastructure-manager/main/golangci-lint)](https://github.com/kyma-project/kyma-infrastructure-manager/actions/workflows/golangci-lint.yaml)
-[![latest release](https://badgen.net/github/release/kyma-project/kyma-infrastructure-manager)](https://github.com/kyma-project/kyma-infrastructure-manager/releases/latest)
+[![golangci lint](https://badgers.space/github/checks/kyma-project/kyma-infrastructure-manager/main/golangci-lint)](https://github.com/kyma-project/kyma-infrastructure-manager/actions/workflows/golangci-lint.yaml)
+[![latest release](https://badgers.space/github/release/kyma-project/kyma-infrastructure-manager)](https://github.com/kyma-project/kyma-infrastructure-manager/releases/latest)
 
 # Kyma Infrastructure Manager
 


### PR DESCRIPTION
**Description**

The badgen.net service has been experiencing ongoing periods of downtime and instability, likely related to its lack of active maintenance in recent years. There is no public, official incident report specifying exactly how long the current outage has lasted, but recent developer discussions and posts mention persistent issues with reliability and broken images. Monitoring platform and user reports do not indicate a clear recent restoration, suggesting the downtime is either ongoing or recurring

Changes proposed in this pull request:

- Replace badgen.net with badgers.space
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
