### PR TITLE
Fix documentation links in operator README

### DIFF
--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -56,7 +56,7 @@ For more information on the structure and purpose of various fields, see the CRD
 
 Example:
 
-https://github.com/kyma-project/kyma-infrastructure-manager/tree/1.24.0/config/crd/bases
+`https://github.com/kyma-project/kyma-infrastructure-manager/tree/1.24.0/config/crd/bases`
 
 #### State Machine
 
@@ -66,7 +66,7 @@ The reconciliation process is implemented using a [state machine pattern](https:
 
 To address the requirements for implementing KIM features, the following sub-components are introduced:
 
-* KIM Snatch: Automatically installed on all Kyma runtimes. To prevent assigning Kyma workloads to worker pools created by customers, KIM Snatch assigns Kyma workloads to the Kyma worker pool. For more information, see the [KIM Snatch documentation](https://github.com/kyma-project/kim-snatch/tree/main/docs/user).
+* KIM Snatch: Automatically installed on all Kyma runtimes. To prevent assigning Kyma workloads to worker pools created by customers, KIM Snatch assigns Kyma workloads to the Kyma worker pool. For more information, see the [KIM Snatch documentation](https://github.com/kyma-project/kim-snatch/blob/main/README.md).
 * Gardener Syncer: A Kubernetes CronJob synchronizing Seed cluster data from the Gardener cluster to KCP. KEB uses this data for customer input validation (primarily for the "Colocate Control Plane" feature to detect if a Seed cluster exists in a particular Shoot region). The Seed data is stored in a ConfigMap in KCP. For more information, see the [Gardener Syncer documentation](https://github.com/kyma-project/gardener-syncer/blob/main/README.md).
 
 ## Operations


### PR DESCRIPTION
Updated links in the README to point to the correct documentation files.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fixed documentation links in operator README

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
