### PR TITLE
chore: update Go version to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/infrastructure-manager
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary

Update Go toolchain to the latest available version (1.26.2) for bug fixes and improvements.

- Update `go.mod` directive from 1.26.0 to 1.26.2
- Update Docker build image from `golang:1.26.1-alpine3.22` to `golang:1.26.2-alpine3.22`

## Test plan

- [ ] Verify build succeeds locally
- [ ] Verify CI tests pass