### PR TITLE
Configure Renovate and CI for GitHub merge queue support

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -12,6 +12,7 @@ on:
         labeled,
         milestoned,
       ]
+  merge_group:
 
 jobs:
   all-checks:

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,6 @@
   ],
   "prHourlyLimit": 0,
   "rebaseWhen": "conflicted",
-  "platformAutomerge": true,
-  "automergeType": "pr",
   "gomod": {
     "postUpdateOptions": [
       "gomodTidy"

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,9 @@
     "schedule:earlyMondays"
   ],
   "prHourlyLimit": 0,
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
+  "platformAutomerge": true,
+  "automergeType": "pr",
   "gomod": {
     "postUpdateOptions": [
       "gomodTidy"
@@ -36,7 +38,9 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Switch Renovate `automerge` to PR-based strategy with `platformAutomerge: true` so GitHub's merge queue handles actual merging instead of Renovate calling the GitHub API directly
- Change `rebaseWhen` from `behind-base-branch` to `conflicted` to avoid unnecessary rebases while the queue orders PRs
- Add `merge_group` trigger to the `all-checks-passed` workflow so required status checks fire inside the merge queue and it does not stall

## Test Plan

- [ ] Enable merge queue on branch protection rules for `main`
- [ ] Verify a Renovate PR for a minor/patch dependency is automerged via the queue (not directly by Renovate)
- [ ] Verify the `all-checks-passed` check appears in merge queue runs