### PR TITLE
Add feature to copy dedicated auditlog read credentials to SKR

### DIFF
--- a/api/v1/runtime_types.go
+++ b/api/v1/runtime_types.go
@@ -61,15 +61,16 @@ const (
 type RuntimeConditionType string
 
 const (
-	ConditionTypeRuntimeProvisioned       RuntimeConditionType = "Provisioned"
-	ConditionTypeRuntimeKubeconfigReady   RuntimeConditionType = "KubeconfigReady"
-	ConditionTypeOidcAndCMsConfigured     RuntimeConditionType = "OidcAndConfigMapConfigured"
-	ConditionTypeKymaSystemCreated        RuntimeConditionType = "KymaSystemNSCreated"
-	ConditionTypeRuntimeConfigured        RuntimeConditionType = "Configured"
-	ConditionTypeRuntimeDeprovisioned     RuntimeConditionType = "Deprovisioned"
-	ConditionTypeRegistryCacheConfigured  RuntimeConditionType = "RegistryCacheConfigured"
-	ConditionTypeRuntimeBootstrapperReady RuntimeConditionType = "RuntimeBootstrapperReady"
-	ConditionTypeCustomAuditLogConfigured RuntimeConditionType = "CustomAuditLogConfigured"
+	ConditionTypeRuntimeProvisioned        RuntimeConditionType = "Provisioned"
+	ConditionTypeRuntimeKubeconfigReady    RuntimeConditionType = "KubeconfigReady"
+	ConditionTypeOidcAndCMsConfigured      RuntimeConditionType = "OidcAndConfigMapConfigured"
+	ConditionTypeKymaSystemCreated         RuntimeConditionType = "KymaSystemNSCreated"
+	ConditionTypeRuntimeConfigured         RuntimeConditionType = "Configured"
+	ConditionTypeRuntimeDeprovisioned      RuntimeConditionType = "Deprovisioned"
+	ConditionTypeRegistryCacheConfigured   RuntimeConditionType = "RegistryCacheConfigured"
+	ConditionTypeRuntimeBootstrapperReady  RuntimeConditionType = "RuntimeBootstrapperReady"
+	ConditionTypeCustomAuditLogConfigured  RuntimeConditionType = "CustomAuditLogConfigured"
+	ConditionTypeAuditLogCredentialsCopied RuntimeConditionType = "AuditLogCredentialsCopied"
 )
 
 type RuntimeConditionReason string
@@ -98,6 +99,8 @@ const (
 	ConditionReasonAuditLogError            = RuntimeConditionReason("AuditLogErr")
 	ConditionReasonCustomAuditLogError      = RuntimeConditionReason("CustomAuditLogErr")
 	ConditionReasonCustomAuditLogConfigured = RuntimeConditionReason("CustomAuditLogConfigured")
+	ConditionReasonCredentialsCopyError     = RuntimeConditionReason("CredentialsCopyErr")
+	ConditionReasonCredentialsCopied        = RuntimeConditionReason("CredentialsCopied")
 
 	ConditionReasonAdministratorsConfigured = RuntimeConditionReason("AdministratorsConfigured")
 	ConditionReasonOidcAndCMsConfigured     = RuntimeConditionReason("OidcAndConfigMapsConfigured")

--- a/docs/adr/005-copy-auditlog-read-credentials-implementation.md
+++ b/docs/adr/005-copy-auditlog-read-credentials-implementation.md
@@ -1,0 +1,319 @@
+# Copy Audit Log Read Credentials - Implementation Details
+
+This document provides detailed implementation guidance for the read credentials copy feature described in [ADR 005: Copy Audit Log Read Credentials](./005-copy-auditlog-read-credentials.md).
+
+## Table of Contents
+
+- [AuditLogData Structure Extension](#auditlogdata-structure-extension)
+- [FSM State Implementation](#fsm-state-implementation)
+- [State Transition Flow](#state-transition-flow)
+- [Condition Types](#condition-types)
+- [Error Handling](#error-handling)
+- [Idempotency](#idempotency)
+
+## AuditLogData Structure Extension
+
+The `AuditLogData` struct in `pkg/auditlog/shared.go` is extended with the read credentials secret name:
+
+```go
+type AuditLogData struct {
+    TenantID            string `json:"tenantID" validate:"required"`
+    ServiceURL          string `json:"serviceURL" validate:"required,url"`
+    SecretName          string `json:"secretName" validate:"required"`
+    ReadCredsSecretName string `json:"readCredsSecretName,omitempty"` // Only used for dedicated audit logging
+}
+```
+
+The `GetDedicatedAuditLogData` method in `pkg/auditlog/provider.go` populates this field from the AuditLogCR:
+
+```go
+return AuditLogData{
+    TenantID:            reserved.Spec.SubaccountID,
+    ServiceURL:          reserved.Spec.Config.ServiceURL,
+    SecretName:          reserved.Spec.Config.GardenerSecretName,
+    ReadCredsSecretName: reserved.Spec.Config.ReadCredsSecretName,
+}, nil
+```
+
+## FSM State Implementation
+
+### File Location
+
+`internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials.go`
+
+### State Function
+
+```go
+func sFnCopyAuditLogReadCredentials(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
+    m.log.V(log_level.DEBUG).Info("Copying audit log read credentials to SKR")
+
+    runtimeID := s.instance.Labels[imv1.LabelKymaRuntimeID]
+
+    // Get audit log data - uses cached client, essentially free
+    auditLogData, err := m.AuditLogDataProvider.GetDedicatedAuditLogData(ctx, runtimeID, false)
+    if err != nil {
+        // Handle error - update condition, requeue
+    }
+
+    // Skip if no read credentials configured
+    if auditLogData.ReadCredsSecretName == "" {
+        m.log.Info("No read credentials secret configured, skipping copy", "runtimeID", runtimeID)
+        completeProvisioning(&s.instance)
+        return updateStatusAndStop()
+    }
+
+    // Copy credentials to SKR
+    if err := copyReadCredentialsToSKR(ctx, m, s, auditLogData.ReadCredsSecretName); err != nil {
+        // Handle error - update condition, requeue
+    }
+
+    // Success - update condition, complete provisioning
+    s.instance.UpdateStateReady(
+        imv1.ConditionTypeAuditLogCredentialsCopied,
+        imv1.ConditionReasonCredentialsCopied,
+        "Audit log read credentials copied to runtime",
+    )
+
+    completeProvisioning(&s.instance)
+    return updateStatusAndStop()
+}
+```
+
+### Helper Function: copyReadCredentialsToSKR
+
+```go
+func copyReadCredentialsToSKR(ctx context.Context, m *fsm, s *systemState, sourceSecretName string) error {
+    // 1. Get SKR client
+    runtimeClient, err := m.RuntimeClientGetter.Get(ctx, s.instance)
+    if err != nil {
+        return fmt.Errorf("failed to get runtime client: %w", err)
+    }
+
+    // 2. Read source secret from KCP namespace
+    var sourceSecret corev1.Secret
+    secretKey := types.NamespacedName{
+        Name:      sourceSecretName,
+        Namespace: s.instance.Namespace,
+    }
+    if err := m.KcpClient.Get(ctx, secretKey, &sourceSecret); err != nil {
+        return fmt.Errorf("failed to get source secret %s: %w", secretKey, err)
+    }
+
+    // 3. Create target secret for SKR
+    targetSecret := corev1.Secret{
+        TypeMeta: metav1.TypeMeta{
+            APIVersion: "v1",
+            Kind:       "Secret",
+        },
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      "auditlog-read-credentials",
+            Namespace: "kyma-system",
+            Labels: map[string]string{
+                imv1.LabelKymaManagedBy: "infrastructure-manager",
+            },
+        },
+        Data: sourceSecret.Data,
+        Type: sourceSecret.Type,
+    }
+
+    // 4. Apply secret with server-side apply (idempotent)
+    if err := runtimeClient.Patch(ctx, &targetSecret, client.Apply, &client.PatchOptions{
+        FieldManager: fieldManagerName,
+        Force:        ptr.To(true),
+    }); err != nil {
+        return fmt.Errorf("failed to apply secret to SKR: %w", err)
+    }
+
+    return nil
+}
+```
+
+### Helper Function: completeProvisioning
+
+```go
+func completeProvisioning(instance *imv1.Runtime) {
+    if !instance.IsProvisioningCompletedStatusSet() {
+        instance.UpdateStateProvisioningCompleted()
+    }
+}
+```
+
+## State Transition Flow
+
+### Modified sFnMigrateToDedicatedAuditLog
+
+The `sFnMigrateToDedicatedAuditLog` state now chains to the new state instead of completing provisioning:
+
+```go
+// When configs are equal (no patch needed)
+if configsEqual {
+    s.instance.UpdateStateReady(
+        imv1.ConditionTypeCustomAuditLogConfigured,
+        imv1.ConditionReasonCustomAuditLogConfigured,
+        "Custom AuditLog shoot configuration completed",
+    )
+    
+    // Chain to credentials copy state (instead of updateStatusAndStop)
+    return switchState(sFnCopyAuditLogReadCredentials)
+}
+```
+
+### Complete Flow Diagram
+
+```
+sFnApplyClusterRoleBindings
+    │
+    ├─── (dedicated audit logging enabled) ───────────────────────┐
+    │                                                              │
+    │                                                              ▼
+    │                                              sFnMigrateToDedicatedAuditLog
+    │                                                              │
+    │                                    ┌─────────────────────────┼─────────────────────────┐
+    │                                    │                         │                         │
+    │                              (claim failed)            (configs differ)          (configs equal)
+    │                                    │                         │                         │
+    │                                    ▼                         ▼                         │
+    │                               FAIL + STOP              Patch shoot                     │
+    │                                                              │                         │
+    │                                    ┌─────────────────────────┤                         │
+    │                                    │                         │                         │
+    │                              (patch failed)           (patch success)                  │
+    │                                    │                         │                         │
+    │                                    ▼                         ▼                         │
+    │                               Requeue              Requeue (wait Gardener)             │
+    │                                                              │                         │
+    │                                                              │ (next reconciliation)   │
+    │                                                              │                         │
+    │                                                              └─────────────────────────┤
+    │                                                                                        │
+    │                                                                                        ▼
+    │                                                              sFnCopyAuditLogReadCredentials
+    │                                                                                        │
+    │                                    ┌───────────────────────────────────────────────────┤
+    │                                    │                         │                         │
+    │                             (data fetch failed)     (no read creds)              (copy success)
+    │                                    │                         │                         │
+    │                                    ▼                         │                         │
+    │                               Requeue                        │                         │
+    │                                                              │                         │
+    │                                    ┌─────────────────────────┼─────────────────────────┤
+    │                                    │                         │                         │
+    │                              (copy failed)                   │                         │
+    │                                    │                         │                         │
+    │                                    ▼                         ▼                         ▼
+    │                               Requeue              Complete Provisioning    Complete Provisioning
+    │                                                              │                         │
+    │                                                              └───────────┬─────────────┘
+    │                                                                          │
+    ├─── (dedicated audit logging disabled) ───────────────────────────────────┤
+    │                                                                          │
+    ▼                                                                          ▼
+Complete Provisioning                                              updateStatusAndStop()
+```
+
+## Condition Types
+
+### New Condition Type
+
+Added to `api/v1/runtime_types.go`:
+
+```go
+ConditionTypeAuditLogCredentialsCopied RuntimeConditionType = "AuditLogCredentialsCopied"
+```
+
+### New Condition Reasons
+
+```go
+ConditionReasonCredentialsCopyError = RuntimeConditionReason("CredentialsCopyErr")
+ConditionReasonCredentialsCopied    = RuntimeConditionReason("CredentialsCopied")
+```
+
+### Runtime Status Conditions Example
+
+After successful provisioning with dedicated audit logging:
+
+```yaml
+status:
+  conditions:
+    - type: CustomAuditLogConfigured
+      status: "True"
+      reason: CustomAuditLogConfigured
+      message: "Custom AuditLog shoot configuration completed"
+    - type: AuditLogCredentialsCopied
+      status: "True"
+      reason: CredentialsCopied
+      message: "Audit log read credentials copied to runtime"
+```
+
+## Error Handling
+
+| Scenario | Condition Status | Reason | Action |
+|----------|-----------------|--------|--------|
+| GetDedicatedAuditLogData fails | False | CredentialsCopyErr | Requeue with ControlPlaneRequeueDuration |
+| Runtime client unavailable | False | CredentialsCopyErr | Requeue with ControlPlaneRequeueDuration |
+| Source secret not found | False | CredentialsCopyErr | Requeue with ControlPlaneRequeueDuration |
+| Apply to SKR fails | False | CredentialsCopyErr | Requeue with ControlPlaneRequeueDuration |
+| ReadCredsSecretName empty | (no condition) | - | Skip copy, complete provisioning |
+| Success | True | CredentialsCopied | Complete provisioning |
+
+## Idempotency
+
+The implementation is fully idempotent:
+
+1. **GetDedicatedAuditLogData with claim=false**: Re-fetches data without side effects using cached client
+2. **Server-side apply**: Using `client.Apply` with `Force: true` ensures:
+   - Secret is created if it doesn't exist
+   - Secret is updated if it exists with different data
+   - No error if secret already exists with same data
+3. **completeProvisioning helper**: Checks `IsProvisioningCompletedStatusSet()` before updating
+4. **Safe re-entry**: State can be re-entered on any reconciliation without issues
+
+## Target Secret Specification
+
+| Property | Value |
+|----------|-------|
+| Name | `auditlog-read-credentials` |
+| Namespace | `kyma-system` |
+| Label | `operator.kyma-project.io/managed-by: infrastructure-manager` |
+| Content | Copied from source secret (OAuth credentials) |
+
+## Cleanup
+
+Secret cleanup is automatic:
+
+1. Runtime deletion triggers shoot deletion
+2. SKR cluster deletion includes `kyma-system` namespace deletion
+3. All secrets in `kyma-system` are garbage collected
+4. No explicit cleanup code required in KIM
+
+## Testing
+
+### Unit Tests
+
+File: `internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials_test.go`
+
+Test cases:
+1. `should copy credentials and complete provisioning` - Happy path
+2. `should skip copy and complete when ReadCredsSecretName is empty` - No-op case
+3. `should requeue on GetDedicatedAuditLogData error` - Data fetch failure
+4. `should requeue on runtime client error` - SKR client failure
+5. `should requeue when source secret not found` - Source secret missing
+6. `should handle idempotent re-runs when secret already exists` - Update existing secret
+
+### Integration Testing
+
+Manual verification steps:
+1. Create Runtime CR with `auditLogAccessEnabled: true`
+2. Wait for provisioning to complete
+3. Verify `CustomAuditLogConfigured` condition is True
+4. Verify `AuditLogCredentialsCopied` condition is True
+5. Connect to SKR cluster
+6. Verify secret exists: `kubectl get secret auditlog-read-credentials -n kyma-system`
+7. Verify secret has correct labels and data
+
+## References
+
+- [ADR 005: Copy Audit Log Read Credentials](./005-copy-auditlog-read-credentials.md)
+- [ADR 004: Dedicated Audit Logging](./004-dedicated-audit-logging.md)
+- [ADR 004: Implementation Details](./004-dedicated-audit-logging-implementation.md)
+- [AuditLog Types Definition](../../pkg/auditlog/v1beta1/auditlog_types.go)

--- a/docs/adr/005-copy-auditlog-read-credentials.md
+++ b/docs/adr/005-copy-auditlog-read-credentials.md
@@ -1,0 +1,308 @@
+# Context
+
+This document defines the architecture for copying dedicated audit log read credentials to the Kyma Runtime cluster (SKR) as part of the dedicated audit logging feature described in [ADR 004: Dedicated Audit Logging](./004-dedicated-audit-logging.md).
+
+# Status
+
+Proposed
+
+# Background
+
+The dedicated audit logging feature (ADR 004) implements a two-phase process:
+1. **Phase 1**: Reserve an AuditLogCR before shoot creation
+2. **Phase 2**: Claim the AuditLogCR and patch the shoot with dedicated write credentials in `sFnMigrateToDedicatedAuditLog`
+
+However, according to KALM architecture specifications, there is a third step missing: **copying read credentials to the runtime cluster** to enable users to access their audit logs directly.
+
+## Current Gap
+
+The `sFnMigrateToDedicatedAuditLog` function currently:
+- ✅ Claims the AuditLogCR (upgrades reservation to full claim)
+- ✅ Reads write credentials configuration from AuditLogCR
+- ✅ Patches shoot with audit log extension configuration (destination URL, tenant ID, Gardener secret)
+- ❌ **Missing**: Copy read credentials to the runtime cluster
+
+## Read Credentials Overview
+
+The AuditLogCR contains a reference to read credentials in `spec.config.readCredsSecretName`. This secret:
+- Lives in the KCP namespace alongside the AuditLogCR
+- Contains OAuth credentials for read-only access to audit logs
+- Is managed by KALM (Kyma Audit Log Manager)
+- Needs to be copied to the SKR's `kyma-system` namespace as `auditlog-read-credentials`
+
+Users can then use these credentials to query their dedicated audit logs via the audit log service API.
+
+# Decision
+
+## Architectural Approach
+
+We extend the `sFnMigrateToDedicatedAuditLog` state to include read credentials copy as a **final step** after successfully patching the shoot. This approach:
+
+1. Groups all dedicated audit log operations in a single FSM state
+2. Maintains the existing flow without adding new FSM states
+3. Copies credentials only after shoot configuration succeeds
+
+### Extended FSM State Flow
+
+```
+sFnMigrateToDedicatedAuditLog:
+    Step 1: Claim AuditLogCR (existing)
+    Step 2: Get current shoot config (existing)
+    Step 3: Compare configurations (existing)
+    Step 4: Patch shoot if needed (existing)
+    Step 5: Copy read credentials to SKR (NEW)
+    Step 6: Complete provisioning
+```
+
+## Implementation Details
+
+### Extending AuditLogData Structure
+
+Add read credentials secret name to the `AuditLogData` struct:
+
+```go
+type AuditLogData struct {
+    TenantID              string
+    ServiceURL            string
+    SecretName            string  // Write credentials (Gardener secret)
+    ReadCredsSecretName   string  // Read credentials (KCP namespace) - NEW
+}
+```
+
+### Extending GetDedicatedAuditLogData
+
+The `GetDedicatedAuditLogData` method in `pkg/auditlog/provider.go` already returns data from the AuditLogCR. We extend it to include the read credentials secret name:
+
+```go
+return AuditLogData{
+    TenantID:            auditLogCR.Spec.SubaccountID,
+    ServiceURL:          auditLogCR.Spec.Config.ServiceURL,
+    SecretName:          auditLogCR.Spec.Config.GardenerSecretName,
+    ReadCredsSecretName: auditLogCR.Spec.Config.ReadCredsSecretName,  // NEW
+}, nil
+```
+
+### New Helper Function: copyReadCredentialsToSKR
+
+```go
+func copyReadCredentialsToSKR(ctx context.Context, m *fsm, s *systemState, auditLogData auditlog.AuditLogData) error {
+    // Skip if no read credentials configured
+    if auditLogData.ReadCredsSecretName == "" {
+        m.log.Info("No read credentials secret configured, skipping copy")
+        return nil
+    }
+
+    // Get SKR client
+    runtimeClient, err := m.RuntimeClientGetter.Get(ctx, s.instance)
+    if err != nil {
+        return fmt.Errorf("failed to get runtime client: %w", err)
+    }
+
+    // Read source secret from KCP namespace
+    var sourceSecret corev1.Secret
+    secretKey := types.NamespacedName{
+        Name:      auditLogData.ReadCredsSecretName,
+        Namespace: s.instance.Namespace,  // KCP namespace where AuditLogCR lives
+    }
+    if err := m.Client.Get(ctx, secretKey, &sourceSecret); err != nil {
+        return fmt.Errorf("failed to get read credentials secret %s: %w", secretKey, err)
+    }
+
+    // Create target secret for SKR
+    targetSecret := corev1.Secret{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      "auditlog-read-credentials",
+            Namespace: "kyma-system",
+            Labels: map[string]string{
+                imv1.LabelKymaManagedBy: "infrastructure-manager",
+            },
+        },
+        Data: sourceSecret.Data,
+        Type: sourceSecret.Type,
+    }
+
+    // Apply secret with server-side apply (idempotent)
+    if err := runtimeClient.Patch(ctx, &targetSecret, client.Apply, &client.PatchOptions{
+        FieldManager: fieldManagerName,
+        Force:        ptr.To(true),
+    }); err != nil {
+        return fmt.Errorf("failed to apply read credentials secret to SKR: %w", err)
+    }
+
+    return nil
+}
+```
+
+### Extended sFnMigrateToDedicatedAuditLog
+
+```go
+func sFnMigrateToDedicatedAuditLog(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
+    // ... existing checks for feature flags ...
+
+    // Step 1: Claim AuditLogCR (existing)
+    auditLogData, err := m.AuditLogDataProvider.GetDedicatedAuditLogData(ctx, runtimeID, true)
+    if err != nil {
+        // ... existing error handling ...
+    }
+
+    // Step 2-4: Compare and patch shoot (existing)
+    // ... existing code ...
+
+    // Step 5: Copy read credentials to SKR (NEW)
+    if err := copyReadCredentialsToSKR(ctx, m, s, auditLogData); err != nil {
+        m.log.Error(err, "Failed to copy read credentials to SKR, will retry",
+            "runtimeID", runtimeID)
+        
+        s.instance.UpdateStatePending(
+            imv1.ConditionTypeCustomAuditLogConfigured,
+            imv1.ConditionReasonCustomAuditLogError,
+            metav1.ConditionFalse,
+            fmt.Sprintf("Failed to copy read credentials: %v", err),
+        )
+        
+        return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
+    }
+
+    m.log.Info("Successfully copied read credentials to SKR",
+        "runtimeID", runtimeID,
+        "secretName", auditLogData.ReadCredsSecretName)
+
+    // Step 6: Complete provisioning (existing)
+    // ... existing completion code ...
+}
+```
+
+## Target Secret Specification
+
+| Property | Value |
+|----------|-------|
+| Name | `auditlog-read-credentials` |
+| Namespace | `kyma-system` |
+| Label | `kyma-project.io/managed-by: infrastructure-manager` |
+| Content | OAuth credentials (copied from source secret data) |
+
+## Error Handling
+
+### Source Secret Not Found
+
+If `AuditLogCR.spec.config.readCredsSecretName` references a non-existent secret:
+- Log error with details
+- Update condition with error message
+- Requeue for retry (KALM may not have created the secret yet)
+
+### SKR Client Unavailable
+
+If runtime client cannot be obtained (kubeconfig issues):
+- Log error
+- Update condition with error message
+- Requeue for retry
+
+### Apply Failure
+
+If server-side apply fails:
+- Log error with details
+- Update condition with error message
+- Requeue for retry
+
+### No Read Credentials Configured
+
+If `readCredsSecretName` is empty:
+- Log info message (not an error)
+- Skip copy operation
+- Continue with provisioning completion
+
+## Idempotency
+
+The implementation is fully idempotent:
+
+1. **Server-side apply**: Using `client.Apply` with force ensures the secret is created or updated correctly
+2. **No duplicate creates**: Patch-based approach handles both create and update scenarios
+3. **Safe retries**: Failed copy operations can be retried without side effects
+4. **Reconciliation-safe**: Next reconciliation will apply the same secret state
+
+## Cleanup
+
+Read credentials secret cleanup is **automatic** and does not require explicit implementation:
+
+1. When a runtime is deleted, the `kyma-system` namespace in SKR is deleted
+2. All secrets in `kyma-system`, including `auditlog-read-credentials`, are garbage collected
+3. No orphaned secrets remain
+
+This aligns with the existing behavior for other SKR resources managed by KIM.
+
+# Rejected Alternatives
+
+## Alternative 1: Separate FSM State
+
+**Approach**: Create a new state `sFnCopyAuditLogReadCredentials` after `sFnMigrateToDedicatedAuditLog`
+
+**Rejected because**:
+- Adds complexity with additional FSM state
+- Requires extra reconciliation iteration
+- Logically part of the same "migrate to dedicated" operation
+- No clear benefit from separation
+
+## Alternative 2: Copy Before Shoot Patch
+
+**Approach**: Copy read credentials before patching the shoot
+
+**Rejected because**:
+- Credentials should only be available after configuration succeeds
+- If shoot patch fails, credentials would exist without valid audit log setup
+- Conceptually, users get access after everything is configured
+
+## Alternative 3: Sync During Every Reconciliation
+
+**Approach**: Always sync read credentials during reconciliation, not just during provisioning
+
+**Rejected because**:
+- Unnecessary overhead for runtime operations
+- Credentials don't change during runtime lifecycle
+- KALM credentials are immutable once set
+
+## Alternative 4: Copy Credentials to Gardener Secret Store
+
+**Approach**: Store read credentials in Gardener secrets (like write credentials)
+
+**Rejected because**:
+- Write credentials are for Gardener's audit log extension
+- Read credentials are for user access, not Gardener
+- Different lifecycle and purpose
+
+# Consequences
+
+## Positive
+
+1. **Complete feature**: Users can access dedicated audit logs with provided credentials
+2. **Simple implementation**: Extends existing state without new FSM states
+3. **Idempotent**: Server-side apply ensures safe retries
+4. **Self-cleaning**: Namespace deletion handles cleanup
+5. **Consistent pattern**: Follows existing SKR secret management patterns (registry cache)
+
+## Negative
+
+1. **Additional network call**: Requires runtime client connection to SKR
+2. **Retry loop**: Failed copy triggers requeue, may delay provisioning completion
+3. **Cross-cluster dependency**: Relies on SKR availability
+
+## Neutral
+
+1. **Conditional behavior**: Only executes when `readCredsSecretName` is set
+2. **KALM dependency**: Requires KALM to populate read credentials secret
+
+# Implementation Checklist
+
+- [ ] Extend `AuditLogData` struct with `ReadCredsSecretName` field
+- [ ] Update `GetDedicatedAuditLogData` to return read credentials secret name
+- [ ] Implement `copyReadCredentialsToSKR` helper function
+- [ ] Extend `sFnMigrateToDedicatedAuditLog` with read credentials copy
+- [ ] Add unit tests for `copyReadCredentialsToSKR`
+- [ ] Add integration tests for end-to-end flow
+- [ ] Update documentation
+
+# References
+
+- [Issue #1496: Copy dedicated audit log read credentials](https://github.com/kyma-project/kyma-infrastructure-manager/issues/1496)
+- [ADR 004: Dedicated Audit Logging](./004-dedicated-audit-logging.md)
+- [ADR 004: Implementation Details](./004-dedicated-audit-logging-implementation.md)
+- [AuditLog Types Definition](../../pkg/auditlog/v1beta1/auditlog_types.go)

--- a/docs/adr/005-copy-auditlog-read-credentials.md
+++ b/docs/adr/005-copy-auditlog-read-credentials.md
@@ -4,7 +4,7 @@ This document defines the architecture for copying dedicated audit log read cred
 
 # Status
 
-Proposed
+Implemented
 
 # Background
 
@@ -32,144 +32,92 @@ The AuditLogCR contains a reference to read credentials in `spec.config.readCred
 
 Users can then use these credentials to query their dedicated audit logs via the audit log service API.
 
+## Current FSM Flow (Provisioning)
+
+```
+sFnCreateShoot
+    ↓
+sFnWaitForShootCreation
+    ↓
+sFnHandleKubeconfig
+    ↓
+sFnCreateKymaNamespace          ← Creates kyma-system namespace in SKR
+    ↓
+sFnInitializeRuntimeBootstrapper
+    ↓
+sFnCleanupRegistryCacheGardenSecrets
+    ↓
+sFnConfigureSKR                 ← Applies ConfigMap + OIDC to SKR
+    ↓
+sFnApplyClusterRoleBindings     ← Applies ClusterRoleBindings to SKR
+    ↓
+sFnMigrateToDedicatedAuditLog   ← Claims AuditLogCR, patches shoot
+    ↓
+Complete (updateStatusAndStop)
+```
+
+# Decision Options
+
+## Option 1: Extend sFnMigrateToDedicatedAuditLog
+
+Add read credentials copy as a final step within the existing `sFnMigrateToDedicatedAuditLog` state.
+
+### Pros
+- Logical grouping of all dedicated audit log operations
+- No new FSM states
+- Simple flow
+
+### Cons
+- Mixed concerns (Gardener vs SKR operations)
+- State complexity increases
+- Requeue ambiguity
+
+---
+
+## Option 2: Use Existing SKR Configuration State
+
+Extend `sFnConfigureSKR` or `sFnApplyClusterRoleBindings`.
+
+### Pros
+- Reuses existing SKR client
+- Follows existing patterns
+
+### Cons
+- Semantic mismatch
+- **Temporal coupling issue**: Credentials copied BEFORE shoot is configured
+- Feature flag complexity in unrelated states
+
+---
+
+## Option 3: Create New State sFnCopyAuditLogReadCredentials (Selected)
+
+Create a dedicated state that runs after `sFnMigrateToDedicatedAuditLog`.
+
+### Pros
+- Clean separation of concerns
+- Correct temporal ordering
+- Independent error handling
+- Better observability with separate conditions
+- Testable in isolation
+
+### Cons
+- Additional FSM state
+- Extra reconciliation iteration
+
 # Decision
 
-## Architectural Approach
+We create a new FSM state `sFnCopyAuditLogReadCredentials` that executes after `sFnMigrateToDedicatedAuditLog` to copy read credentials to SKR.
 
-We extend the `sFnMigrateToDedicatedAuditLog` state to include read credentials copy as a **final step** after successfully patching the shoot. This approach:
-
-1. Groups all dedicated audit log operations in a single FSM state
-2. Maintains the existing flow without adding new FSM states
-3. Copies credentials only after shoot configuration succeeds
-
-### Extended FSM State Flow
+## New FSM Flow
 
 ```
-sFnMigrateToDedicatedAuditLog:
-    Step 1: Claim AuditLogCR (existing)
-    Step 2: Get current shoot config (existing)
-    Step 3: Compare configurations (existing)
-    Step 4: Patch shoot if needed (existing)
-    Step 5: Copy read credentials to SKR (NEW)
-    Step 6: Complete provisioning
-```
-
-## Implementation Details
-
-### Extending AuditLogData Structure
-
-Add read credentials secret name to the `AuditLogData` struct:
-
-```go
-type AuditLogData struct {
-    TenantID              string
-    ServiceURL            string
-    SecretName            string  // Write credentials (Gardener secret)
-    ReadCredsSecretName   string  // Read credentials (KCP namespace) - NEW
-}
-```
-
-### Extending GetDedicatedAuditLogData
-
-The `GetDedicatedAuditLogData` method in `pkg/auditlog/provider.go` already returns data from the AuditLogCR. We extend it to include the read credentials secret name:
-
-```go
-return AuditLogData{
-    TenantID:            auditLogCR.Spec.SubaccountID,
-    ServiceURL:          auditLogCR.Spec.Config.ServiceURL,
-    SecretName:          auditLogCR.Spec.Config.GardenerSecretName,
-    ReadCredsSecretName: auditLogCR.Spec.Config.ReadCredsSecretName,  // NEW
-}, nil
-```
-
-### New Helper Function: copyReadCredentialsToSKR
-
-```go
-func copyReadCredentialsToSKR(ctx context.Context, m *fsm, s *systemState, auditLogData auditlog.AuditLogData) error {
-    // Skip if no read credentials configured
-    if auditLogData.ReadCredsSecretName == "" {
-        m.log.Info("No read credentials secret configured, skipping copy")
-        return nil
-    }
-
-    // Get SKR client
-    runtimeClient, err := m.RuntimeClientGetter.Get(ctx, s.instance)
-    if err != nil {
-        return fmt.Errorf("failed to get runtime client: %w", err)
-    }
-
-    // Read source secret from KCP namespace
-    var sourceSecret corev1.Secret
-    secretKey := types.NamespacedName{
-        Name:      auditLogData.ReadCredsSecretName,
-        Namespace: s.instance.Namespace,  // KCP namespace where AuditLogCR lives
-    }
-    if err := m.Client.Get(ctx, secretKey, &sourceSecret); err != nil {
-        return fmt.Errorf("failed to get read credentials secret %s: %w", secretKey, err)
-    }
-
-    // Create target secret for SKR
-    targetSecret := corev1.Secret{
-        ObjectMeta: metav1.ObjectMeta{
-            Name:      "auditlog-read-credentials",
-            Namespace: "kyma-system",
-            Labels: map[string]string{
-                imv1.LabelKymaManagedBy: "infrastructure-manager",
-            },
-        },
-        Data: sourceSecret.Data,
-        Type: sourceSecret.Type,
-    }
-
-    // Apply secret with server-side apply (idempotent)
-    if err := runtimeClient.Patch(ctx, &targetSecret, client.Apply, &client.PatchOptions{
-        FieldManager: fieldManagerName,
-        Force:        ptr.To(true),
-    }); err != nil {
-        return fmt.Errorf("failed to apply read credentials secret to SKR: %w", err)
-    }
-
-    return nil
-}
-```
-
-### Extended sFnMigrateToDedicatedAuditLog
-
-```go
-func sFnMigrateToDedicatedAuditLog(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
-    // ... existing checks for feature flags ...
-
-    // Step 1: Claim AuditLogCR (existing)
-    auditLogData, err := m.AuditLogDataProvider.GetDedicatedAuditLogData(ctx, runtimeID, true)
-    if err != nil {
-        // ... existing error handling ...
-    }
-
-    // Step 2-4: Compare and patch shoot (existing)
-    // ... existing code ...
-
-    // Step 5: Copy read credentials to SKR (NEW)
-    if err := copyReadCredentialsToSKR(ctx, m, s, auditLogData); err != nil {
-        m.log.Error(err, "Failed to copy read credentials to SKR, will retry",
-            "runtimeID", runtimeID)
-        
-        s.instance.UpdateStatePending(
-            imv1.ConditionTypeCustomAuditLogConfigured,
-            imv1.ConditionReasonCustomAuditLogError,
-            metav1.ConditionFalse,
-            fmt.Sprintf("Failed to copy read credentials: %v", err),
-        )
-        
-        return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
-    }
-
-    m.log.Info("Successfully copied read credentials to SKR",
-        "runtimeID", runtimeID,
-        "secretName", auditLogData.ReadCredsSecretName)
-
-    // Step 6: Complete provisioning (existing)
-    // ... existing completion code ...
-}
+sFnApplyClusterRoleBindings
+    ↓
+sFnMigrateToDedicatedAuditLog   ← Claims AuditLogCR, patches shoot
+    ↓
+sFnCopyAuditLogReadCredentials  ← NEW: Copies read credentials to SKR
+    ↓
+Complete (updateStatusAndStop)
 ```
 
 ## Target Secret Specification
@@ -178,131 +126,46 @@ func sFnMigrateToDedicatedAuditLog(ctx context.Context, m *fsm, s *systemState) 
 |----------|-------|
 | Name | `auditlog-read-credentials` |
 | Namespace | `kyma-system` |
-| Label | `kyma-project.io/managed-by: infrastructure-manager` |
+| Label | `operator.kyma-project.io/managed-by: infrastructure-manager` |
 | Content | OAuth credentials (copied from source secret data) |
-
-## Error Handling
-
-### Source Secret Not Found
-
-If `AuditLogCR.spec.config.readCredsSecretName` references a non-existent secret:
-- Log error with details
-- Update condition with error message
-- Requeue for retry (KALM may not have created the secret yet)
-
-### SKR Client Unavailable
-
-If runtime client cannot be obtained (kubeconfig issues):
-- Log error
-- Update condition with error message
-- Requeue for retry
-
-### Apply Failure
-
-If server-side apply fails:
-- Log error with details
-- Update condition with error message
-- Requeue for retry
-
-### No Read Credentials Configured
-
-If `readCredsSecretName` is empty:
-- Log info message (not an error)
-- Skip copy operation
-- Continue with provisioning completion
-
-## Idempotency
-
-The implementation is fully idempotent:
-
-1. **Server-side apply**: Using `client.Apply` with force ensures the secret is created or updated correctly
-2. **No duplicate creates**: Patch-based approach handles both create and update scenarios
-3. **Safe retries**: Failed copy operations can be retried without side effects
-4. **Reconciliation-safe**: Next reconciliation will apply the same secret state
-
-## Cleanup
-
-Read credentials secret cleanup is **automatic** and does not require explicit implementation:
-
-1. When a runtime is deleted, the `kyma-system` namespace in SKR is deleted
-2. All secrets in `kyma-system`, including `auditlog-read-credentials`, are garbage collected
-3. No orphaned secrets remain
-
-This aligns with the existing behavior for other SKR resources managed by KIM.
-
-# Rejected Alternatives
-
-## Alternative 1: Separate FSM State
-
-**Approach**: Create a new state `sFnCopyAuditLogReadCredentials` after `sFnMigrateToDedicatedAuditLog`
-
-**Rejected because**:
-- Adds complexity with additional FSM state
-- Requires extra reconciliation iteration
-- Logically part of the same "migrate to dedicated" operation
-- No clear benefit from separation
-
-## Alternative 2: Copy Before Shoot Patch
-
-**Approach**: Copy read credentials before patching the shoot
-
-**Rejected because**:
-- Credentials should only be available after configuration succeeds
-- If shoot patch fails, credentials would exist without valid audit log setup
-- Conceptually, users get access after everything is configured
-
-## Alternative 3: Sync During Every Reconciliation
-
-**Approach**: Always sync read credentials during reconciliation, not just during provisioning
-
-**Rejected because**:
-- Unnecessary overhead for runtime operations
-- Credentials don't change during runtime lifecycle
-- KALM credentials are immutable once set
-
-## Alternative 4: Copy Credentials to Gardener Secret Store
-
-**Approach**: Store read credentials in Gardener secrets (like write credentials)
-
-**Rejected because**:
-- Write credentials are for Gardener's audit log extension
-- Read credentials are for user access, not Gardener
-- Different lifecycle and purpose
 
 # Consequences
 
 ## Positive
 
 1. **Complete feature**: Users can access dedicated audit logs with provided credentials
-2. **Simple implementation**: Extends existing state without new FSM states
-3. **Idempotent**: Server-side apply ensures safe retries
-4. **Self-cleaning**: Namespace deletion handles cleanup
-5. **Consistent pattern**: Follows existing SKR secret management patterns (registry cache)
+2. **Clean architecture**: Each state has single responsibility
+3. **Correct ordering**: Credentials available only after shoot configuration
+4. **Better observability**: Separate conditions for each operation
+5. **Idempotent**: Server-side apply ensures safe retries
+6. **Self-cleaning**: Namespace deletion handles cleanup
+7. **Testable**: States can be tested independently
 
 ## Negative
 
-1. **Additional network call**: Requires runtime client connection to SKR
-2. **Retry loop**: Failed copy triggers requeue, may delay provisioning completion
-3. **Cross-cluster dependency**: Relies on SKR availability
+1. **Additional FSM state**: Increases state count by one
+2. **Extra reconciliation iteration**: One more state transition during provisioning
 
 ## Neutral
 
-1. **Conditional behavior**: Only executes when `readCredsSecretName` is set
+1. **Conditional execution**: State only executed when dedicated logging enabled
 2. **KALM dependency**: Requires KALM to populate read credentials secret
 
-# Implementation Checklist
+# Implementation
 
-- [ ] Extend `AuditLogData` struct with `ReadCredsSecretName` field
-- [ ] Update `GetDedicatedAuditLogData` to return read credentials secret name
-- [ ] Implement `copyReadCredentialsToSKR` helper function
-- [ ] Extend `sFnMigrateToDedicatedAuditLog` with read credentials copy
-- [ ] Add unit tests for `copyReadCredentialsToSKR`
-- [ ] Add integration tests for end-to-end flow
-- [ ] Update documentation
+See [Implementation Details](./005-copy-auditlog-read-credentials-implementation.md) for comprehensive implementation guidance including:
+
+- AuditLogData structure extension
+- FSM state implementation
+- State transition flow diagram
+- Condition types
+- Error handling
+- Idempotency guarantees
+- Testing approach
 
 # References
 
 - [Issue #1496: Copy dedicated audit log read credentials](https://github.com/kyma-project/kyma-infrastructure-manager/issues/1496)
 - [ADR 004: Dedicated Audit Logging](./004-dedicated-audit-logging.md)
 - [ADR 004: Implementation Details](./004-dedicated-audit-logging-implementation.md)
-- [AuditLog Types Definition](../../pkg/auditlog/v1beta1/auditlog_types.go)
+- [Implementation Details](./005-copy-auditlog-read-credentials-implementation.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,3 +8,4 @@ This folder contains architecture decision records.
 - [Configure registry cache functionality](./002-registry-cache.md)
 - [Configure registry cache functionality v2](./003-registry-cache-v2.md)
 - [Dedicated BTP audit logging integration](./004-dedicated-audit-logging.md)
+- [Copy audit log read credentials to SKR](./005-copy-auditlog-read-credentials.md)

--- a/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials.go
@@ -1,0 +1,124 @@
+package fsm
+
+import (
+	"context"
+	"fmt"
+
+	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"github.com/kyma-project/infrastructure-manager/internal/log_level"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const auditLogReadCredentialsSecretName = "auditlog-read-credentials"
+
+// sFnCopyAuditLogReadCredentials copies the audit log read credentials from KCP to SKR
+// This state executes after sFnMigrateToDedicatedAuditLog successfully configures the shoot
+// with dedicated audit logging. It copies the read credentials secret to the runtime cluster
+// to enable users to access their audit logs.
+func sFnCopyAuditLogReadCredentials(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
+	m.log.V(log_level.DEBUG).Info("Copying audit log read credentials to SKR")
+
+	runtimeID := s.instance.Labels[imv1.LabelKymaRuntimeID]
+
+	// Get audit log data - uses cached client, essentially free
+	auditLogData, err := m.AuditLogDataProvider.GetDedicatedAuditLogData(ctx, runtimeID, false)
+	if err != nil {
+		m.log.Error(err, "Failed to get audit log data for credentials copy", "runtimeID", runtimeID)
+		s.instance.UpdateStatePending(
+			imv1.ConditionTypeAuditLogCredentialsCopied,
+			imv1.ConditionReasonCredentialsCopyError,
+			metav1.ConditionFalse,
+			fmt.Sprintf("Failed to get audit log data: %v", err),
+		)
+		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
+	}
+
+	// Skip if no read credentials configured
+	if auditLogData.ReadCredsSecretName == "" {
+		m.log.Info("No read credentials secret configured, skipping copy", "runtimeID", runtimeID)
+		completeProvisioning(&s.instance)
+		return updateStatusAndStop()
+	}
+
+	// Copy credentials to SKR
+	if err := copyReadCredentialsToSKR(ctx, m, s, auditLogData.ReadCredsSecretName); err != nil {
+		m.log.Error(err, "Failed to copy read credentials to SKR", "runtimeID", runtimeID)
+		s.instance.UpdateStatePending(
+			imv1.ConditionTypeAuditLogCredentialsCopied,
+			imv1.ConditionReasonCredentialsCopyError,
+			metav1.ConditionFalse,
+			fmt.Sprintf("Failed to copy read credentials: %v", err),
+		)
+		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
+	}
+
+	m.log.Info("Successfully copied read credentials to SKR",
+		"runtimeID", runtimeID,
+		"sourceSecret", auditLogData.ReadCredsSecretName)
+
+	s.instance.UpdateStateReady(
+		imv1.ConditionTypeAuditLogCredentialsCopied,
+		imv1.ConditionReasonCredentialsCopied,
+		"Audit log read credentials copied to runtime",
+	)
+
+	completeProvisioning(&s.instance)
+	return updateStatusAndStop()
+}
+
+func copyReadCredentialsToSKR(ctx context.Context, m *fsm, s *systemState, sourceSecretName string) error {
+	// Get SKR client
+	runtimeClient, err := m.RuntimeClientGetter.Get(ctx, s.instance)
+	if err != nil {
+		return fmt.Errorf("failed to get runtime client: %w", err)
+	}
+
+	// Read source secret from KCP namespace
+	var sourceSecret corev1.Secret
+	secretKey := types.NamespacedName{
+		Name:      sourceSecretName,
+		Namespace: s.instance.Namespace,
+	}
+	if err := m.KcpClient.Get(ctx, secretKey, &sourceSecret); err != nil {
+		return fmt.Errorf("failed to get source secret %s: %w", secretKey, err)
+	}
+
+	// Create target secret for SKR
+	targetSecret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      auditLogReadCredentialsSecretName,
+			Namespace: "kyma-system",
+			Labels: map[string]string{
+				imv1.LabelKymaManagedBy: "infrastructure-manager",
+			},
+		},
+		Data: sourceSecret.Data,
+		Type: sourceSecret.Type,
+	}
+
+	// Apply secret with server-side apply (idempotent)
+	//nolint:staticcheck // SA1019: client.Apply is used with Patch, which is the correct API for this version
+	if err := runtimeClient.Patch(ctx, &targetSecret, client.Apply, &client.PatchOptions{
+		FieldManager: fieldManagerName,
+		Force:        ptr.To(true),
+	}); err != nil {
+		return fmt.Errorf("failed to apply secret to SKR: %w", err)
+	}
+
+	return nil
+}
+
+func completeProvisioning(instance *imv1.Runtime) {
+	if !instance.IsProvisioningCompletedStatusSet() {
+		instance.UpdateStateProvisioningCompleted()
+	}
+}

--- a/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials.go
@@ -7,11 +7,10 @@ import (
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/log_level"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const auditLogReadCredentialsSecretName = "auditlog-read-credentials"
@@ -25,7 +24,6 @@ func sFnCopyAuditLogReadCredentials(ctx context.Context, m *fsm, s *systemState)
 
 	runtimeID := s.instance.Labels[imv1.LabelKymaRuntimeID]
 
-	// Get audit log data - uses cached client, essentially free
 	auditLogData, err := m.AuditLogDataProvider.GetDedicatedAuditLogData(ctx, runtimeID, false)
 	if err != nil {
 		m.log.Error(err, "Failed to get audit log data for credentials copy", "runtimeID", runtimeID)
@@ -38,14 +36,18 @@ func sFnCopyAuditLogReadCredentials(ctx context.Context, m *fsm, s *systemState)
 		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
 	}
 
-	// Skip if no read credentials configured
+	// Requeue if no read credentials configured - KALM may not have populated the secret yet
 	if auditLogData.ReadCredsSecretName == "" {
-		m.log.Info("No read credentials secret configured, skipping copy", "runtimeID", runtimeID)
-		completeProvisioning(&s.instance)
-		return updateStatusAndStop()
+		m.log.Info("No read credentials secret configured, waiting for KALM to populate", "runtimeID", runtimeID)
+		s.instance.UpdateStatePending(
+			imv1.ConditionTypeAuditLogCredentialsCopied,
+			imv1.ConditionReasonCredentialsCopyError,
+			metav1.ConditionFalse,
+			"Waiting for read credentials secret to be configured",
+		)
+		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
 	}
 
-	// Copy credentials to SKR
 	if err := copyReadCredentialsToSKR(ctx, m, s, auditLogData.ReadCredsSecretName); err != nil {
 		m.log.Error(err, "Failed to copy read credentials to SKR", "runtimeID", runtimeID)
 		s.instance.UpdateStatePending(
@@ -72,15 +74,13 @@ func sFnCopyAuditLogReadCredentials(ctx context.Context, m *fsm, s *systemState)
 }
 
 func copyReadCredentialsToSKR(ctx context.Context, m *fsm, s *systemState, sourceSecretName string) error {
-	// Get SKR client
 	runtimeClient, err := m.RuntimeClientGetter.Get(ctx, s.instance)
 	if err != nil {
 		return fmt.Errorf("failed to get runtime client: %w", err)
 	}
 
-	// Read source secret from KCP namespace
 	var sourceSecret corev1.Secret
-	secretKey := types.NamespacedName{
+	secretKey := k8stypes.NamespacedName{
 		Name:      sourceSecretName,
 		Namespace: s.instance.Namespace,
 	}
@@ -88,32 +88,45 @@ func copyReadCredentialsToSKR(ctx context.Context, m *fsm, s *systemState, sourc
 		return fmt.Errorf("failed to get source secret %s: %w", secretKey, err)
 	}
 
-	// Create target secret for SKR
-	targetSecret := corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      auditLogReadCredentialsSecretName,
-			Namespace: "kyma-system",
-			Labels: map[string]string{
-				imv1.LabelKymaManagedBy: "infrastructure-manager",
+	targetKey := k8stypes.NamespacedName{
+		Name:      auditLogReadCredentialsSecretName,
+		Namespace: "kyma-system",
+	}
+	var existingSecret corev1.Secret
+	err = runtimeClient.Get(ctx, targetKey, &existingSecret)
+
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check existing secret: %w", err)
+	}
+
+	if apierrors.IsNotFound(err) {
+		newSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      auditLogReadCredentialsSecretName,
+				Namespace: "kyma-system",
+				Labels: map[string]string{
+					imv1.LabelKymaManagedBy: "infrastructure-manager",
+				},
 			},
-		},
-		Data: sourceSecret.Data,
-		Type: sourceSecret.Type,
+			Data: sourceSecret.Data,
+			Type: sourceSecret.Type,
+		}
+		if err := runtimeClient.Create(ctx, newSecret); err != nil {
+			return fmt.Errorf("failed to create secret in SKR: %w", err)
+		}
+		return nil
 	}
 
-	// Apply secret with server-side apply (idempotent)
-	//nolint:staticcheck // SA1019: client.Apply is used with Patch, which is the correct API for this version
-	if err := runtimeClient.Patch(ctx, &targetSecret, client.Apply, &client.PatchOptions{
-		FieldManager: fieldManagerName,
-		Force:        ptr.To(true),
-	}); err != nil {
-		return fmt.Errorf("failed to apply secret to SKR: %w", err)
+	existingSecret.Data = sourceSecret.Data
+	existingSecret.Type = sourceSecret.Type
+	if existingSecret.Labels == nil {
+		existingSecret.Labels = make(map[string]string)
 	}
+	existingSecret.Labels[imv1.LabelKymaManagedBy] = "infrastructure-manager"
 
+	if err := runtimeClient.Update(ctx, &existingSecret); err != nil {
+		return fmt.Errorf("failed to update secret in SKR: %w", err)
+	}
 	return nil
 }
 

--- a/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials_test.go
@@ -1,0 +1,474 @@
+package fsm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"github.com/kyma-project/infrastructure-manager/internal/controller/metrics/mocks"
+	fsm_mocks "github.com/kyma-project/infrastructure-manager/internal/controller/runtime/fsm/mocks"
+	"github.com/kyma-project/infrastructure-manager/pkg/auditlog"
+	auditlogmocks "github.com/kyma-project/infrastructure-manager/pkg/auditlog/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSFnCopyAuditLogReadCredentials(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := "test-runtime-id"
+	namespace := "kcp-system"
+
+	t.Run("should copy credentials and complete provisioning", func(t *testing.T) {
+		// given
+		sourceSecretName := "test-read-credentials"
+		sourceSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sourceSecretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"clientid":     []byte("test-client-id"),
+				"clientsecret": []byte("test-client-secret"),
+			},
+			Type: corev1.SecretTypeOpaque,
+		}
+
+		instance := &imv1.Runtime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-runtime",
+				Namespace: namespace,
+				Labels: map[string]string{
+					imv1.LabelKymaRuntimeID: runtimeID,
+				},
+			},
+		}
+
+		// Create kyma-system namespace for target secret
+		kymaSystemNs := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kyma-system",
+			},
+		}
+
+		mockAuditLogProvider := &auditlogmocks.DataProvider{}
+		mockAuditLogProvider.On("GetDedicatedAuditLogData", ctx, runtimeID, false).
+			Return(auditlog.AuditLogData{
+				TenantID:            "test-tenant",
+				ServiceURL:          "https://auditlog.example.com",
+				SecretName:          "gardener-secret",
+				ReadCredsSecretName: sourceSecretName,
+			}, nil)
+
+		mockMetrics := &mocks.Metrics{}
+		scheme, _ := newCreateTestScheme()
+
+		// KCP client with the source secret
+		kcpClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(sourceSecret).
+			Build()
+
+		// SKR client (runtime client)
+		skrClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(kymaSystemNs).
+			Build()
+
+		runtimeClientGetter := &fsm_mocks.RuntimeClientGetter{}
+		runtimeClientGetter.On("Get", mock.Anything, mock.Anything).Return(skrClient, nil)
+
+		testFsm := &fsm{
+			K8s: K8s{
+				KcpClient:           kcpClient,
+				RuntimeClientGetter: runtimeClientGetter,
+			},
+			RCCfg: RCCfg{
+				AuditLogDataProvider: mockAuditLogProvider,
+				Metrics:              mockMetrics,
+			},
+		}
+
+		systemState := &systemState{
+			instance: *instance,
+		}
+
+		// when
+		stateFn, result, err := sFnCopyAuditLogReadCredentials(ctx, testFsm, systemState)
+
+		// then
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Contains(t, stateFn.name(), "updateStatusAndStop")
+		require.True(t, systemState.instance.IsProvisioningCompletedStatusSet())
+
+		// Verify condition is set
+		condition := meta.FindStatusCondition(systemState.instance.Status.Conditions, string(imv1.ConditionTypeAuditLogCredentialsCopied))
+		require.NotNil(t, condition)
+		require.Equal(t, metav1.ConditionTrue, condition.Status)
+		require.Equal(t, string(imv1.ConditionReasonCredentialsCopied), condition.Reason)
+
+		// Verify secret was created in SKR
+		var targetSecret corev1.Secret
+		err = skrClient.Get(ctx, client.ObjectKey{Name: auditLogReadCredentialsSecretName, Namespace: "kyma-system"}, &targetSecret)
+		require.NoError(t, err)
+		require.Equal(t, sourceSecret.Data, targetSecret.Data)
+		require.Equal(t, "infrastructure-manager", targetSecret.Labels[imv1.LabelKymaManagedBy])
+
+		mockAuditLogProvider.AssertExpectations(t)
+		runtimeClientGetter.AssertExpectations(t)
+	})
+
+	t.Run("should skip copy and complete when ReadCredsSecretName is empty", func(t *testing.T) {
+		// given
+		instance := &imv1.Runtime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-runtime",
+				Namespace: namespace,
+				Labels: map[string]string{
+					imv1.LabelKymaRuntimeID: runtimeID,
+				},
+			},
+		}
+
+		mockAuditLogProvider := &auditlogmocks.DataProvider{}
+		mockAuditLogProvider.On("GetDedicatedAuditLogData", ctx, runtimeID, false).
+			Return(auditlog.AuditLogData{
+				TenantID:            "test-tenant",
+				ServiceURL:          "https://auditlog.example.com",
+				SecretName:          "gardener-secret",
+				ReadCredsSecretName: "", // empty - no read credentials
+			}, nil)
+
+		mockMetrics := &mocks.Metrics{}
+		scheme, _ := newCreateTestScheme()
+		kcpClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		testFsm := &fsm{
+			K8s: K8s{
+				KcpClient: kcpClient,
+			},
+			RCCfg: RCCfg{
+				AuditLogDataProvider: mockAuditLogProvider,
+				Metrics:              mockMetrics,
+			},
+		}
+
+		systemState := &systemState{
+			instance: *instance,
+		}
+
+		// when
+		stateFn, result, err := sFnCopyAuditLogReadCredentials(ctx, testFsm, systemState)
+
+		// then
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Contains(t, stateFn.name(), "updateStatusAndStop")
+		require.True(t, systemState.instance.IsProvisioningCompletedStatusSet())
+
+		// No condition should be set for credentials copy (skipped)
+		condition := meta.FindStatusCondition(systemState.instance.Status.Conditions, string(imv1.ConditionTypeAuditLogCredentialsCopied))
+		require.Nil(t, condition)
+
+		mockAuditLogProvider.AssertExpectations(t)
+	})
+
+	t.Run("should requeue on GetDedicatedAuditLogData error", func(t *testing.T) {
+		// given
+		instance := &imv1.Runtime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-runtime",
+				Namespace: namespace,
+				Labels: map[string]string{
+					imv1.LabelKymaRuntimeID: runtimeID,
+				},
+			},
+		}
+
+		mockAuditLogProvider := &auditlogmocks.DataProvider{}
+		mockAuditLogProvider.On("GetDedicatedAuditLogData", ctx, runtimeID, false).
+			Return(auditlog.AuditLogData{}, errors.New("failed to get audit log data"))
+
+		mockMetrics := &mocks.Metrics{}
+		scheme, _ := newCreateTestScheme()
+		kcpClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		requeueDuration := 5 * time.Second
+		testFsm := &fsm{
+			K8s: K8s{
+				KcpClient: kcpClient,
+			},
+			RCCfg: RCCfg{
+				AuditLogDataProvider:        mockAuditLogProvider,
+				Metrics:                     mockMetrics,
+				ControlPlaneRequeueDuration: requeueDuration,
+			},
+		}
+
+		systemState := &systemState{
+			instance: *instance,
+		}
+
+		// when
+		stateFn, result, err := sFnCopyAuditLogReadCredentials(ctx, testFsm, systemState)
+
+		// then
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Contains(t, stateFn.name(), "sFnUpdateStatus")
+
+		// Verify error condition is set
+		condition := meta.FindStatusCondition(systemState.instance.Status.Conditions, string(imv1.ConditionTypeAuditLogCredentialsCopied))
+		require.NotNil(t, condition)
+		require.Equal(t, metav1.ConditionFalse, condition.Status)
+		require.Equal(t, string(imv1.ConditionReasonCredentialsCopyError), condition.Reason)
+
+		mockAuditLogProvider.AssertExpectations(t)
+	})
+
+	t.Run("should requeue on runtime client error", func(t *testing.T) {
+		// given
+		sourceSecretName := "test-read-credentials"
+		instance := &imv1.Runtime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-runtime",
+				Namespace: namespace,
+				Labels: map[string]string{
+					imv1.LabelKymaRuntimeID: runtimeID,
+				},
+			},
+		}
+
+		mockAuditLogProvider := &auditlogmocks.DataProvider{}
+		mockAuditLogProvider.On("GetDedicatedAuditLogData", ctx, runtimeID, false).
+			Return(auditlog.AuditLogData{
+				TenantID:            "test-tenant",
+				ServiceURL:          "https://auditlog.example.com",
+				SecretName:          "gardener-secret",
+				ReadCredsSecretName: sourceSecretName,
+			}, nil)
+
+		mockMetrics := &mocks.Metrics{}
+		scheme, _ := newCreateTestScheme()
+		kcpClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		runtimeClientGetter := &fsm_mocks.RuntimeClientGetter{}
+		runtimeClientGetter.On("Get", mock.Anything, mock.Anything).Return(nil, errors.New("failed to get runtime client"))
+
+		requeueDuration := 5 * time.Second
+		testFsm := &fsm{
+			K8s: K8s{
+				KcpClient:           kcpClient,
+				RuntimeClientGetter: runtimeClientGetter,
+			},
+			RCCfg: RCCfg{
+				AuditLogDataProvider:        mockAuditLogProvider,
+				Metrics:                     mockMetrics,
+				ControlPlaneRequeueDuration: requeueDuration,
+			},
+		}
+
+		systemState := &systemState{
+			instance: *instance,
+		}
+
+		// when
+		stateFn, result, err := sFnCopyAuditLogReadCredentials(ctx, testFsm, systemState)
+
+		// then
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Contains(t, stateFn.name(), "sFnUpdateStatus")
+
+		// Verify error condition is set
+		condition := meta.FindStatusCondition(systemState.instance.Status.Conditions, string(imv1.ConditionTypeAuditLogCredentialsCopied))
+		require.NotNil(t, condition)
+		require.Equal(t, metav1.ConditionFalse, condition.Status)
+		require.Equal(t, string(imv1.ConditionReasonCredentialsCopyError), condition.Reason)
+
+		mockAuditLogProvider.AssertExpectations(t)
+		runtimeClientGetter.AssertExpectations(t)
+	})
+
+	t.Run("should requeue when source secret not found", func(t *testing.T) {
+		// given
+		sourceSecretName := "non-existent-secret"
+		instance := &imv1.Runtime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-runtime",
+				Namespace: namespace,
+				Labels: map[string]string{
+					imv1.LabelKymaRuntimeID: runtimeID,
+				},
+			},
+		}
+
+		mockAuditLogProvider := &auditlogmocks.DataProvider{}
+		mockAuditLogProvider.On("GetDedicatedAuditLogData", ctx, runtimeID, false).
+			Return(auditlog.AuditLogData{
+				TenantID:            "test-tenant",
+				ServiceURL:          "https://auditlog.example.com",
+				SecretName:          "gardener-secret",
+				ReadCredsSecretName: sourceSecretName,
+			}, nil)
+
+		mockMetrics := &mocks.Metrics{}
+		scheme, _ := newCreateTestScheme()
+
+		// KCP client without the source secret
+		kcpClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		// SKR client
+		skrClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		runtimeClientGetter := &fsm_mocks.RuntimeClientGetter{}
+		runtimeClientGetter.On("Get", mock.Anything, mock.Anything).Return(skrClient, nil)
+
+		requeueDuration := 5 * time.Second
+		testFsm := &fsm{
+			K8s: K8s{
+				KcpClient:           kcpClient,
+				RuntimeClientGetter: runtimeClientGetter,
+			},
+			RCCfg: RCCfg{
+				AuditLogDataProvider:        mockAuditLogProvider,
+				Metrics:                     mockMetrics,
+				ControlPlaneRequeueDuration: requeueDuration,
+			},
+		}
+
+		systemState := &systemState{
+			instance: *instance,
+		}
+
+		// when
+		stateFn, result, err := sFnCopyAuditLogReadCredentials(ctx, testFsm, systemState)
+
+		// then
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Contains(t, stateFn.name(), "sFnUpdateStatus")
+
+		// Verify error condition is set
+		condition := meta.FindStatusCondition(systemState.instance.Status.Conditions, string(imv1.ConditionTypeAuditLogCredentialsCopied))
+		require.NotNil(t, condition)
+		require.Equal(t, metav1.ConditionFalse, condition.Status)
+		require.Equal(t, string(imv1.ConditionReasonCredentialsCopyError), condition.Reason)
+
+		mockAuditLogProvider.AssertExpectations(t)
+		runtimeClientGetter.AssertExpectations(t)
+	})
+
+	t.Run("should handle idempotent re-runs when secret already exists", func(t *testing.T) {
+		// given
+		sourceSecretName := "test-read-credentials"
+		sourceSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sourceSecretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"clientid":     []byte("updated-client-id"),
+				"clientsecret": []byte("updated-client-secret"),
+			},
+			Type: corev1.SecretTypeOpaque,
+		}
+
+		// Existing secret in SKR with different data
+		existingTargetSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      auditLogReadCredentialsSecretName,
+				Namespace: "kyma-system",
+				Labels: map[string]string{
+					imv1.LabelKymaManagedBy: "infrastructure-manager",
+				},
+			},
+			Data: map[string][]byte{
+				"clientid":     []byte("old-client-id"),
+				"clientsecret": []byte("old-client-secret"),
+			},
+			Type: corev1.SecretTypeOpaque,
+		}
+
+		instance := &imv1.Runtime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-runtime",
+				Namespace: namespace,
+				Labels: map[string]string{
+					imv1.LabelKymaRuntimeID: runtimeID,
+				},
+			},
+		}
+
+		kymaSystemNs := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kyma-system",
+			},
+		}
+
+		mockAuditLogProvider := &auditlogmocks.DataProvider{}
+		mockAuditLogProvider.On("GetDedicatedAuditLogData", ctx, runtimeID, false).
+			Return(auditlog.AuditLogData{
+				TenantID:            "test-tenant",
+				ServiceURL:          "https://auditlog.example.com",
+				SecretName:          "gardener-secret",
+				ReadCredsSecretName: sourceSecretName,
+			}, nil)
+
+		mockMetrics := &mocks.Metrics{}
+		scheme, _ := newCreateTestScheme()
+
+		kcpClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(sourceSecret).
+			Build()
+
+		skrClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(kymaSystemNs, existingTargetSecret).
+			Build()
+
+		runtimeClientGetter := &fsm_mocks.RuntimeClientGetter{}
+		runtimeClientGetter.On("Get", mock.Anything, mock.Anything).Return(skrClient, nil)
+
+		testFsm := &fsm{
+			K8s: K8s{
+				KcpClient:           kcpClient,
+				RuntimeClientGetter: runtimeClientGetter,
+			},
+			RCCfg: RCCfg{
+				AuditLogDataProvider: mockAuditLogProvider,
+				Metrics:              mockMetrics,
+			},
+		}
+
+		systemState := &systemState{
+			instance: *instance,
+		}
+
+		// when
+		stateFn, result, err := sFnCopyAuditLogReadCredentials(ctx, testFsm, systemState)
+
+		// then
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.Contains(t, stateFn.name(), "updateStatusAndStop")
+		require.True(t, systemState.instance.IsProvisioningCompletedStatusSet())
+
+		// Verify secret was updated with new data
+		var targetSecret corev1.Secret
+		err = skrClient.Get(ctx, client.ObjectKey{Name: auditLogReadCredentialsSecretName, Namespace: "kyma-system"}, &targetSecret)
+		require.NoError(t, err)
+		require.Equal(t, sourceSecret.Data, targetSecret.Data)
+
+		mockAuditLogProvider.AssertExpectations(t)
+		runtimeClientGetter.AssertExpectations(t)
+	})
+}

--- a/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_copy_auditlog_credentials_test.go
@@ -125,7 +125,7 @@ func TestSFnCopyAuditLogReadCredentials(t *testing.T) {
 		runtimeClientGetter.AssertExpectations(t)
 	})
 
-	t.Run("should skip copy and complete when ReadCredsSecretName is empty", func(t *testing.T) {
+	t.Run("should requeue when ReadCredsSecretName is empty", func(t *testing.T) {
 		// given
 		instance := &imv1.Runtime{
 			ObjectMeta: metav1.ObjectMeta{
@@ -143,20 +143,22 @@ func TestSFnCopyAuditLogReadCredentials(t *testing.T) {
 				TenantID:            "test-tenant",
 				ServiceURL:          "https://auditlog.example.com",
 				SecretName:          "gardener-secret",
-				ReadCredsSecretName: "", // empty - no read credentials
+				ReadCredsSecretName: "", // empty - KALM hasn't populated it yet
 			}, nil)
 
 		mockMetrics := &mocks.Metrics{}
 		scheme, _ := newCreateTestScheme()
 		kcpClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
+		requeueDuration := 5 * time.Second
 		testFsm := &fsm{
 			K8s: K8s{
 				KcpClient: kcpClient,
 			},
 			RCCfg: RCCfg{
-				AuditLogDataProvider: mockAuditLogProvider,
-				Metrics:              mockMetrics,
+				AuditLogDataProvider:        mockAuditLogProvider,
+				Metrics:                     mockMetrics,
+				ControlPlaneRequeueDuration: requeueDuration,
 			},
 		}
 
@@ -170,12 +172,14 @@ func TestSFnCopyAuditLogReadCredentials(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		require.Nil(t, result)
-		require.Contains(t, stateFn.name(), "updateStatusAndStop")
-		require.True(t, systemState.instance.IsProvisioningCompletedStatusSet())
+		require.Contains(t, stateFn.name(), "sFnUpdateStatus")
+		require.False(t, systemState.instance.IsProvisioningCompletedStatusSet())
 
-		// No condition should be set for credentials copy (skipped)
+		// Verify error condition is set
 		condition := meta.FindStatusCondition(systemState.instance.Status.Conditions, string(imv1.ConditionTypeAuditLogCredentialsCopied))
-		require.Nil(t, condition)
+		require.NotNil(t, condition)
+		require.Equal(t, metav1.ConditionFalse, condition.Status)
+		require.Equal(t, string(imv1.ConditionReasonCredentialsCopyError), condition.Reason)
 
 		mockAuditLogProvider.AssertExpectations(t)
 	})

--- a/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
@@ -77,7 +77,7 @@ func sFnCreateShoot(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl
 			return updateStateFailedWithErrorAndStop(
 				&s.instance,
 				imv1.ConditionTypeRuntimeProvisioned,
-				imv1.ConditionReasonAuditLogError,
+				imv1.ConditionReasonCustomAuditLogError,
 				msg)
 		}
 

--- a/internal/controller/runtime/fsm/runtime_fsm_initialise.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_initialise.go
@@ -29,6 +29,11 @@ func sFnInitialize(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.
 		return addFinalizerAndRequeue(ctx, m, s)
 	}
 
+	if s.instance.Labels[imv1.LabelKymaRuntimeID] == "" {
+		m.log.Error(fmt.Errorf("runtime ID label is missing"), "Runtime ID label is missing on the instance", "instance", s.instance.Name)
+		return updateStatusAndStopWithError(fmt.Errorf("runtime ID label is missing on the instance"))
+	}
+
 	// instance is being deleted
 	if instanceIsBeingDeleted {
 		if s.shoot != nil {

--- a/internal/controller/runtime/fsm/runtime_fsm_initialise_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_initialise_test.go
@@ -2,8 +2,9 @@ package fsm
 
 import (
 	"context"
-	core_v1 "k8s.io/api/core/v1"
 	"time"
+
+	core_v1 "k8s.io/api/core/v1"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
@@ -35,10 +36,14 @@ var _ = Describe("KIM sFnInitialise", func() {
 		}
 	}
 
+	labels := make(map[string]string)
+	labels[imv1.LabelKymaRuntimeID] = "test-runtime-id"
+
 	testRt := imv1.Runtime{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-instance",
 			Namespace: "default",
+			Labels:    labels,
 		},
 	}
 
@@ -47,6 +52,7 @@ var _ = Describe("KIM sFnInitialise", func() {
 			Name:       "test-instance",
 			Namespace:  "default",
 			Finalizers: []string{"test-me-plz"},
+			Labels:     labels,
 		},
 	}
 
@@ -55,6 +61,7 @@ var _ = Describe("KIM sFnInitialise", func() {
 			Name:       "test-instance",
 			Namespace:  "default",
 			Finalizers: []string{"test-me-plz"},
+			Labels:     labels,
 		},
 	}
 
@@ -70,6 +77,7 @@ var _ = Describe("KIM sFnInitialise", func() {
 	testRtWithDeletionTimestamp := imv1.Runtime{
 		ObjectMeta: metav1.ObjectMeta{
 			DeletionTimestamp: &now,
+			Labels:            labels,
 		},
 	}
 
@@ -77,6 +85,7 @@ var _ = Describe("KIM sFnInitialise", func() {
 		ObjectMeta: metav1.ObjectMeta{
 			DeletionTimestamp: &now,
 			Finalizers:        []string{"test-me-plz"},
+			Labels:            labels,
 		},
 	}
 

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog.go
@@ -89,12 +89,8 @@ func sFnMigrateToDedicatedAuditLog(ctx context.Context, m *fsm, s *systemState) 
 			"Custom AuditLog shoot configuration completed",
 		)
 
-		// Complete provisioning
-		if !s.instance.IsProvisioningCompletedStatusSet() {
-			s.instance.UpdateStateProvisioningCompleted()
-		}
-
-		return updateStatusAndStop()
+		// Chain to credentials copy state
+		return switchState(sFnCopyAuditLogReadCredentials)
 	}
 
 	m.log.Info("Shoot audit log configuration differs, patching shoot",

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers.go
@@ -15,65 +15,70 @@ import (
 
 const dedicatedAuditlogSecretReference = "dedicated-auditlog-credentials"
 
-// patchShootAuditLog patches the shoot with dedicated audit log configuration
-// This is a two-part operation:
-// 1. Updates the AuditlogExtension's secretReferenceName to use "dedicated-auditlog-credentials"
-// 2. Adds/updates a NamedResourceReference that maps "dedicated-auditlog-credentials" to the actual Gardener secret
+// patchShootAuditLog patches the shoot with dedicated audit log configuration.
+// It delegates all data mutations to applyDedicatedAuditLogToShoot and then
+// persists the result via the Gardener client.
 func patchShootAuditLog(ctx context.Context, m *fsm, s *systemState, auditLogData auditlog.AuditLogData) error {
-	// Create a copy of the shoot to modify
 	patchedShoot := s.shoot.DeepCopy()
 
-	// Part 1: Find and update the audit log extension
-	found := false
-	for i := range patchedShoot.Spec.Extensions {
-		if patchedShoot.Spec.Extensions[i].Type == extensions.AuditlogExtensionType {
-			// Update the audit log configuration with dedicated settings
-			if err := updateAuditLogExtension(&patchedShoot.Spec.Extensions[i], auditLogData); err != nil {
-				return fmt.Errorf("failed to update audit log extension: %w", err)
-			}
-			found = true
-			break
-		}
+	if err := applyDedicatedAuditLogToShoot(patchedShoot, auditLogData); err != nil {
+		return err
 	}
 
-	if !found {
-		return fmt.Errorf("audit log extension not found in shoot spec")
-	}
-
-	// Part 2: Add or update the secret resource reference
-	resource := gardener.NamedResourceReference{
-		Name: dedicatedAuditlogSecretReference,
-		ResourceRef: v1.CrossVersionObjectReference{
-			Name:       auditLogData.SecretName,
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-	}
-
-	// Find if the resource reference already exists
-	index := slices.IndexFunc(patchedShoot.Spec.Resources, func(r gardener.NamedResourceReference) bool {
-		return r.Name == dedicatedAuditlogSecretReference
-	})
-
-	if index == -1 {
-		// Add new resource reference
-		patchedShoot.Spec.Resources = append(patchedShoot.Spec.Resources, resource)
-	} else {
-		// Update existing resource reference
-		patchedShoot.Spec.Resources[index] = resource
-	}
-
-	// Patch the shoot resource
 	if err := m.GardenClient.Patch(ctx, patchedShoot, client.MergeFrom(s.shoot), &client.PatchOptions{
 		FieldManager: fieldManagerName,
 	}); err != nil {
 		return fmt.Errorf("failed to patch shoot: %w", err)
 	}
 
-	// Update the systemState with the patched shoot
 	s.shoot = patchedShoot
-
 	return nil
+}
+
+// applyDedicatedAuditLogToShoot mutates a shoot with the dedicated audit log configuration.
+// It is a pure function (no I/O) that can be unit-tested in isolation.
+func applyDedicatedAuditLogToShoot(shoot *gardener.Shoot, auditLogData auditlog.AuditLogData) error {
+	if err := updateAuditLogExtensionConfig(shoot, auditLogData); err != nil {
+		return err
+	}
+	upsertAuditLogSecretReference(shoot, auditLogData.SecretName)
+	return nil
+}
+
+// updateAuditLogExtensionConfig finds the audit log extension in the shoot and updates
+// its provider config with the dedicated audit log settings.
+func updateAuditLogExtensionConfig(shoot *gardener.Shoot, auditLogData auditlog.AuditLogData) error {
+	for i := range shoot.Spec.Extensions {
+		if shoot.Spec.Extensions[i].Type != extensions.AuditlogExtensionType {
+			continue
+		}
+		if err := updateAuditLogExtension(&shoot.Spec.Extensions[i], auditLogData); err != nil {
+			return fmt.Errorf("failed to update audit log extension: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("audit log extension not found in shoot spec")
+}
+
+// upsertAuditLogSecretReference adds or updates the NamedResourceReference that maps
+// dedicatedAuditlogSecretReference to the actual Gardener secret.
+func upsertAuditLogSecretReference(shoot *gardener.Shoot, secretName string) {
+	resource := gardener.NamedResourceReference{
+		Name: dedicatedAuditlogSecretReference,
+		ResourceRef: v1.CrossVersionObjectReference{
+			Name:       secretName,
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+	}
+	index := slices.IndexFunc(shoot.Spec.Resources, func(r gardener.NamedResourceReference) bool {
+		return r.Name == dedicatedAuditlogSecretReference
+	})
+	if index == -1 {
+		shoot.Spec.Resources = append(shoot.Spec.Resources, resource)
+		return
+	}
+	shoot.Spec.Resources[index] = resource
 }
 
 // updateAuditLogExtension updates the extension's provider config with dedicated audit log settings
@@ -115,30 +120,31 @@ func getShootAuditLogConfig(shoot *gardener.Shoot) (*auditlog.AuditLogData, erro
 
 	// Find the audit log extension
 	for i := range shoot.Spec.Extensions {
-		if shoot.Spec.Extensions[i].Type == extensions.AuditlogExtensionType {
-			if shoot.Spec.Extensions[i].ProviderConfig == nil {
-				return nil, fmt.Errorf("audit log extension has nil provider config")
-			}
-
-			// Parse the extension config
-			var config extensions.AuditlogExtensionConfig
-			if err := json.Unmarshal(shoot.Spec.Extensions[i].ProviderConfig.Raw, &config); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal audit log config: %w", err)
-			}
-
-			// Look up the actual secret name from shoot.Spec.Resources using the SecretReferenceName
-			secretName, err := getSecretNameFromResources(shoot, config.SecretReferenceName)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get secret name from resources: %w", err)
-			}
-
-			// Return the audit log data
-			return &auditlog.AuditLogData{
-				TenantID:   config.TenantID,
-				ServiceURL: config.ServiceURL,
-				SecretName: secretName,
-			}, nil
+		if shoot.Spec.Extensions[i].Type != extensions.AuditlogExtensionType {
+			continue
 		}
+
+		if shoot.Spec.Extensions[i].ProviderConfig == nil {
+			return nil, fmt.Errorf("audit log extension has nil provider config")
+		}
+
+		// Parse the extension config
+		var config extensions.AuditlogExtensionConfig
+		if err := json.Unmarshal(shoot.Spec.Extensions[i].ProviderConfig.Raw, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal audit log config: %w", err)
+		}
+
+		// Look up the actual secret name from shoot.Spec.Resources using the SecretReferenceName
+		secretName, err := getSecretNameFromResources(shoot, config.SecretReferenceName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get secret name from resources: %w", err)
+		}
+
+		return &auditlog.AuditLogData{
+			TenantID:   config.TenantID,
+			ServiceURL: config.ServiceURL,
+			SecretName: secretName,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("audit log extension not found in shoot spec")

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_test.go
@@ -278,8 +278,8 @@ func TestSFnMigrateToDedicatedAuditLog(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		require.Nil(t, result)
-		require.Contains(t, stateFn.name(), "updateStatusAndStop")
-		require.True(t, systemState.instance.IsProvisioningCompletedStatusSet())
+		// Should transition to credentials copy state
+		require.Contains(t, stateFn.name(), "sFnCopyAuditLogReadCredentials")
 
 		// Verify condition is set to ready (true status)
 		condition := meta.FindStatusCondition(systemState.instance.Status.Conditions, string(imv1.ConditionTypeCustomAuditLogConfigured))

--- a/pkg/auditlog/provider.go
+++ b/pkg/auditlog/provider.go
@@ -58,36 +58,43 @@ func (p *DefaultDataProvider) ReserveAuditLog(ctx context.Context, providerRegio
 // When claim=true, performs Phase 2 of two-phase claim (upgrades reservation to full claim)
 func (p *DefaultDataProvider) GetDedicatedAuditLogData(ctx context.Context, runtimeID string, claim bool) (AuditLogData, error) {
 	if claim {
-		// Phase 2: Find the reserved AuditLogCR and upgrade to claim
-		reserved, err := p.findAuditLogCRByReservation(ctx, runtimeID)
-		if err != nil {
-			return AuditLogData{}, fmt.Errorf("failed to find reserved AuditLogCR: %w", err)
-		}
-		if reserved == nil {
-			return AuditLogData{}, fmt.Errorf("no reservation found for runtime %s", runtimeID)
-		}
+		return p.claimAndGetDedicatedAuditLogData(ctx, runtimeID)
+	}
+	return p.getDedicatedAuditLogDataWithoutClaim(ctx, runtimeID)
+}
 
-		// Upgrade to claim if not already claimed (idempotent)
-		if reserved.Spec.AssignedToRuntimeID != runtimeID {
-			reserved.Spec.AssignedToRuntimeID = runtimeID
-			if err := p.client.Update(ctx, reserved); err != nil {
-				return AuditLogData{}, fmt.Errorf("failed to claim AuditLogCR: %w", err)
-			}
-			p.logger.Info("Successfully claimed AuditLogCR", "runtimeID", runtimeID, "auditLogCR", reserved.Name)
-		} else {
-			p.logger.Info("AuditLogCR already claimed", "runtimeID", runtimeID)
-		}
-
-		// Return the data
-		return AuditLogData{
-			TenantID:            reserved.Spec.SubaccountID,
-			ServiceURL:          reserved.Spec.Config.ServiceURL,
-			SecretName:          reserved.Spec.Config.GardenerSecretName,
-			ReadCredsSecretName: reserved.Spec.Config.ReadCredsSecretName,
-		}, nil
+// claimAndGetDedicatedAuditLogData performs Phase 2 of two-phase claim: upgrades reservation to full claim
+// and returns the audit log configuration
+func (p *DefaultDataProvider) claimAndGetDedicatedAuditLogData(ctx context.Context, runtimeID string) (AuditLogData, error) {
+	reserved, err := p.findAuditLogCRByReservation(ctx, runtimeID)
+	if err != nil {
+		return AuditLogData{}, fmt.Errorf("failed to find reserved AuditLogCR: %w", err)
+	}
+	if reserved == nil {
+		return AuditLogData{}, fmt.Errorf("no reservation found for runtime %s", runtimeID)
 	}
 
-	// claim=false: just retrieve data from already claimed/reserved resource
+	// Upgrade to claim if not already claimed (idempotent)
+	if reserved.Spec.AssignedToRuntimeID != runtimeID {
+		reserved.Spec.AssignedToRuntimeID = runtimeID
+		if err := p.client.Update(ctx, reserved); err != nil {
+			return AuditLogData{}, fmt.Errorf("failed to claim AuditLogCR: %w", err)
+		}
+		p.logger.Info("Successfully claimed AuditLogCR", "runtimeID", runtimeID, "auditLogCR", reserved.Name)
+	} else {
+		p.logger.Info("AuditLogCR already claimed", "runtimeID", runtimeID)
+	}
+
+	return AuditLogData{
+		TenantID:            reserved.Spec.SubaccountID,
+		ServiceURL:          reserved.Spec.Config.ServiceURL,
+		SecretName:          reserved.Spec.Config.GardenerSecretName,
+		ReadCredsSecretName: reserved.Spec.Config.ReadCredsSecretName,
+	}, nil
+}
+
+// getDedicatedAuditLogDataWithoutClaim retrieves audit log data from already claimed/reserved resource
+func (p *DefaultDataProvider) getDedicatedAuditLogDataWithoutClaim(ctx context.Context, runtimeID string) (AuditLogData, error) {
 	// First try to find by claim
 	auditLogCR, err := p.findAuditLogCRByRuntimeID(ctx, runtimeID)
 	if err != nil {

--- a/pkg/auditlog/provider.go
+++ b/pkg/auditlog/provider.go
@@ -80,9 +80,10 @@ func (p *DefaultDataProvider) GetDedicatedAuditLogData(ctx context.Context, runt
 
 		// Return the data
 		return AuditLogData{
-			TenantID:   reserved.Spec.SubaccountID,
-			ServiceURL: reserved.Spec.Config.ServiceURL,
-			SecretName: reserved.Spec.Config.GardenerSecretName,
+			TenantID:            reserved.Spec.SubaccountID,
+			ServiceURL:          reserved.Spec.Config.ServiceURL,
+			SecretName:          reserved.Spec.Config.GardenerSecretName,
+			ReadCredsSecretName: reserved.Spec.Config.ReadCredsSecretName,
 		}, nil
 	}
 
@@ -104,9 +105,10 @@ func (p *DefaultDataProvider) GetDedicatedAuditLogData(ctx context.Context, runt
 	}
 
 	return AuditLogData{
-		TenantID:   auditLogCR.Spec.SubaccountID,
-		ServiceURL: auditLogCR.Spec.Config.ServiceURL,
-		SecretName: auditLogCR.Spec.Config.GardenerSecretName,
+		TenantID:            auditLogCR.Spec.SubaccountID,
+		ServiceURL:          auditLogCR.Spec.Config.ServiceURL,
+		SecretName:          auditLogCR.Spec.Config.GardenerSecretName,
+		ReadCredsSecretName: auditLogCR.Spec.Config.ReadCredsSecretName,
 	}, nil
 }
 

--- a/pkg/auditlog/shared.go
+++ b/pkg/auditlog/shared.go
@@ -18,9 +18,10 @@ type providerType = string
 
 // AuditLogData represents audit log configuration
 type AuditLogData struct {
-	TenantID   string `json:"tenantID" validate:"required"`
-	ServiceURL string `json:"serviceURL" validate:"required,url"`
-	SecretName string `json:"secretName" validate:"required"`
+	TenantID            string `json:"tenantID" validate:"required"`
+	ServiceURL          string `json:"serviceURL" validate:"required,url"`
+	SecretName          string `json:"secretName" validate:"required"`
+	ReadCredsSecretName string `json:"readCredsSecretName,omitempty"` // Only used for dedicated audit logging
 }
 
 // Configuration is the map-based shared audit log configuration


### PR DESCRIPTION
## Copy Dedicated Audit Log Read Credentials to SKR

Closes https://github.com/kyma-project/kyma-infrastructure-manager/issues/1496

### Description

This PR completes the dedicated audit logging feature by copying read credentials to the runtime cluster (SKR). After shoot configuration with dedicated audit log write credentials, users need read credentials to access their audit logs via the audit log service API.

### Key Documents for Review

- [ADR 005: Copy Audit Log Read Credentials](https://github.com/koala7659/infrastructure-manager/blob/copy-auditlog-read-credentials/docs/adr/005-copy-auditlog-read-credentials.md) - Design decision document
- [ADR 005: Implementation Details](https://github.com/koala7659/infrastructure-manager/blob/copy-auditlog-read-credentials/docs/adr/005-copy-auditlog-read-credentials-implementation.md) - Detailed implementation guidance

### Design Decision

Created a new FSM state `sFnCopyAuditLogReadCredentials` that executes after `sFnMigrateToDedicatedAuditLog` (Option 3 from ADR 005). This approach was selected over extending existing states because:

- **Clean separation of concerns** - each state has single responsibility
- **Correct temporal ordering** - credentials are copied only after shoot is fully configured
- **Independent error handling** - failures don't affect shoot configuration
- **Better observability** - separate condition type for monitoring

### Changes

**API Types** (`api/v1/runtime_types.go`)
- Added `ConditionTypeAuditLogCredentialsCopied` condition type
- Added `ConditionReasonCredentialsCopied` and `ConditionReasonCredentialsCopyError` reasons

**AuditLog Package** (`pkg/auditlog/`)
- Extended `AuditLogData` struct with `ReadCredsSecretName` field
- Updated `GetDedicatedAuditLogData` to return read credentials secret name

**FSM States** (`internal/controller/runtime/fsm/`)
- New `sFnCopyAuditLogReadCredentials` state copies secret from KCP to SKR's `kyma-system` namespace
- Modified `sFnMigrateToDedicatedAuditLog` to chain to new state via `switchState()`
- Uses server-side apply for idempotent secret management

### Target Secret

| Property | Value |
|----------|-------|
| Name | `auditlog-read-credentials` |
| Namespace | `kyma-system` |
| Label | `operator.kyma-project.io/managed-by: infrastructure-manager` |

### Testing

- 6 unit tests covering happy path, skip scenarios, error handling, and idempotency
- All existing tests pass

