### PR TITLE
Revert "Add environment protection for secret access in upload-release-report workflow"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,6 @@ jobs:
   upload-release-report:
     needs: generate-release
     if: needs.generate-release.result == 'success'
-    environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/upload-release-report.yaml
+++ b/.github/workflows/upload-release-report.yaml
@@ -27,13 +27,6 @@ jobs:
       contents: read
 
     steps:
-      - name: Validate required environment variable
-        run: |
-          if [ -z "${{ vars.PROTECTED_ENVIRONMENT }}" ]; then
-            echo "::error::Repository variable PROTECTED_ENVIRONMENT is not set. Refusing to continue."
-            exit 1
-          fi
-
       - name: Set release version
         run: |
           echo "RELEASE_VERSION=${{ inputs.release_version }}" >> $GITHUB_ENV


### PR DESCRIPTION
Reverts #1465.

## Reason

The `environment:` key on a job that also uses `uses:` (reusable workflow call) is not supported by GitHub Actions — combining both on the same job causes GitHub to reject the entire workflow file with a "workflow file issue" error. As a result, the `KIM Release` workflow (`release.yaml`) has not run on any tag push since this change landed, blocking all releases including `1.39.1`.

## Impact

Removing `environment: ${{ vars.PROTECTED_ENVIRONMENT }}` from the `upload-release-report` job in `release.yaml` and reverting the related `upload-release-report.yaml` changes restores the workflow to a working state.

If environment protection for the `RELEASE_LOG_UPLOADER_SA` secret is still desired, it needs to be configured inside the reusable workflow (`upload-release-report.yaml`) itself rather than on the calling job.