### PR TITLE
Gardener extension removal functionality

### DIFF
--- a/internal/registrycache/garden_secret_manager_test.go
+++ b/internal/registrycache/garden_secret_manager_test.go
@@ -203,17 +203,16 @@ func TestHasRegistryCacheCountChanged(t *testing.T) {
 
 	t.Run("Should return false if registry cache extension is currently disabled", func(t *testing.T) {
 		// given
-		registryCacheExtension, err := extensions.NewRegistryCacheExtension(nil, map[string]string{}, &gardener.Extension{
+		registryCacheExtension := gardener.Extension{
 			Type:     extensions.RegistryCacheExtensionType,
 			Disabled: ptr.To(true),
 			ProviderConfig: &runtime.RawExtension{
 				Raw: []byte("{}"),
 			},
-		})
-		Expect(err).To(BeNil())
+		}
 
 		// when
-		changed, err := HasRegistryCacheCountChanged([]gardener.Extension{*registryCacheExtension}, []imv1.ImageRegistryCache{cache1})
+		changed, err := HasRegistryCacheCountChanged([]gardener.Extension{registryCacheExtension}, []imv1.ImageRegistryCache{cache1})
 
 		// then
 		Expect(changed).To(Equal(false))

--- a/pkg/gardener/shoot/extender/extensions/extender.go
+++ b/pkg/gardener/shoot/extender/extensions/extender.go
@@ -18,7 +18,7 @@ type CreateExtensionFunc func(runtime imv1.Runtime, shoot gardener.Shoot) (*gard
 type Strategy int
 
 const (
-	StrategySkip Strategy = iota
+	StrategyKeep Strategy = iota
 	StrategyRemove
 )
 
@@ -198,24 +198,19 @@ func newExtensionsExtender(extensionsToApply []Extension, currentGardenerExtensi
 				return err
 			}
 
-			alreadyExists := slices.ContainsFunc(shoot.Spec.Extensions, func(e gardener.Extension) bool {
+			index := slices.IndexFunc(shoot.Spec.Extensions, func(e gardener.Extension) bool {
 				return e.Type == ext.Type
 			})
 
-			if !alreadyExists && updatedGardenerExtension != nil {
-				shoot.Spec.Extensions = append(shoot.Spec.Extensions, *updatedGardenerExtension)
-			}
-
-			if alreadyExists {
-				index := slices.IndexFunc(shoot.Spec.Extensions, func(e gardener.Extension) bool {
-					return e.Type == ext.Type
-				})
-				if index != -1 {
-					if updatedGardenerExtension != nil {
-						shoot.Spec.Extensions[index] = *updatedGardenerExtension
-					} else if ext.Strategy == StrategyRemove {
-						shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, index, index+1)
-					}
+			if index == -1 {
+				if updatedGardenerExtension != nil {
+					shoot.Spec.Extensions = append(shoot.Spec.Extensions, *updatedGardenerExtension)
+				}
+			} else {
+				if updatedGardenerExtension != nil {
+					shoot.Spec.Extensions[index] = *updatedGardenerExtension
+				} else if ext.Strategy == StrategyRemove {
+					shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, index, index+1)
 				}
 			}
 		}

--- a/pkg/gardener/shoot/extender/extensions/extender.go
+++ b/pkg/gardener/shoot/extender/extensions/extender.go
@@ -15,9 +15,17 @@ import (
 
 type CreateExtensionFunc func(runtime imv1.Runtime, shoot gardener.Shoot) (*gardener.Extension, error)
 
+type Strategy int
+
+const (
+	StrategySkip Strategy = iota
+	StrategyRemove
+)
+
 type Extension struct {
-	Type   string
-	Create CreateExtensionFunc
+	Type     string
+	Create   CreateExtensionFunc
+	Strategy Strategy
 }
 
 func NewExtensionsExtenderForCreate(ctx context.Context, kcpClient client.Client, config config.ConverterConfig, auditLogData auditlogs.AuditLogData, apiServerAclEnabled bool) func(runtime imv1.Runtime, shoot *gardener.Shoot) error {
@@ -86,8 +94,9 @@ func NewExtensionsExtenderForCreate(ctx context.Context, kcpClient client.Client
 func NewExtensionsExtenderForPatch(ctx context.Context, kcpClient client.Client, config config.ConverterConfig, auditLogData auditlogs.AuditLogData, extensionsOnTheShoot []gardener.Extension, apiServerAclEnabled bool, registryCacheGardenSecretNames map[string]string) func(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 	return newExtensionsExtender([]Extension{
 		{
-			AuditlogExtensionType,
-			func(_ imv1.Runtime, shoot gardener.Shoot) (*gardener.Extension, error) {
+			Type: AuditlogExtensionType,
+			Create: func(_ imv1.Runtime, shoot gardener.Shoot) (*gardener.Extension, error) {
+
 				if auditLogData == (auditlogs.AuditLogData{}) {
 					return nil, nil
 				}
@@ -138,6 +147,7 @@ func NewExtensionsExtenderForPatch(ctx context.Context, kcpClient client.Client,
 			Create: func(runtime imv1.Runtime, shoot gardener.Shoot) (*gardener.Extension, error) {
 				return NewRegistryCacheExtension(runtime.Spec.Caching, registryCacheGardenSecretNames, existingExtension(RegistryCacheExtensionType, shoot))
 			},
+			Strategy: StrategyRemove,
 		},
 		{
 			Type: ApiServerACLExtensionType,
@@ -188,19 +198,23 @@ func newExtensionsExtender(extensionsToApply []Extension, currentGardenerExtensi
 				return err
 			}
 
-			// If the extension should not be applied we skip it
-			if gardenerExtension == nil {
-				continue
-			}
-
 			index := slices.IndexFunc(currentGardenerExtensions, func(e gardener.Extension) bool {
 				return e.Type == ext.Type
 			})
 
-			if index == -1 {
+			if index == -1 && gardenerExtension != nil {
 				shoot.Spec.Extensions = append(shoot.Spec.Extensions, *gardenerExtension)
-			} else {
-				shoot.Spec.Extensions[index] = *gardenerExtension
+			}
+
+			if index != -1 {
+
+				if gardenerExtension != nil {
+					shoot.Spec.Extensions[index] = *gardenerExtension
+				}
+
+				if ext.Strategy == StrategyRemove {
+					shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, index, index)
+				}
 			}
 		}
 

--- a/pkg/gardener/shoot/extender/extensions/extender.go
+++ b/pkg/gardener/shoot/extender/extensions/extender.go
@@ -198,19 +198,24 @@ func newExtensionsExtender(extensionsToApply []Extension, currentGardenerExtensi
 				return err
 			}
 
-			index := slices.IndexFunc(currentGardenerExtensions, func(e gardener.Extension) bool {
+			existsInCurrent := slices.ContainsFunc(currentGardenerExtensions, func(e gardener.Extension) bool {
 				return e.Type == ext.Type
 			})
 
-			if index == -1 && gardenerExtension != nil {
+			if !existsInCurrent && gardenerExtension != nil {
 				shoot.Spec.Extensions = append(shoot.Spec.Extensions, *gardenerExtension)
 			}
 
-			if index != -1 {
-				if gardenerExtension != nil {
-					shoot.Spec.Extensions[index] = *gardenerExtension
-				} else if ext.Strategy == StrategyRemove {
-					shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, index, index+1)
+			if existsInCurrent {
+				liveIndex := slices.IndexFunc(shoot.Spec.Extensions, func(e gardener.Extension) bool {
+					return e.Type == ext.Type
+				})
+				if liveIndex != -1 {
+					if gardenerExtension != nil {
+						shoot.Spec.Extensions[liveIndex] = *gardenerExtension
+					} else if ext.Strategy == StrategyRemove {
+						shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, liveIndex, liveIndex+1)
+					}
 				}
 			}
 		}

--- a/pkg/gardener/shoot/extender/extensions/extender.go
+++ b/pkg/gardener/shoot/extender/extensions/extender.go
@@ -193,28 +193,28 @@ func newExtensionsExtender(extensionsToApply []Extension, currentGardenerExtensi
 		}
 
 		for _, ext := range extensionsToApply {
-			gardenerExtension, err := ext.Create(runtime, *shoot)
+			updatedGardenerExtension, err := ext.Create(runtime, *shoot)
 			if err != nil {
 				return err
 			}
 
-			existsInCurrent := slices.ContainsFunc(currentGardenerExtensions, func(e gardener.Extension) bool {
+			alreadyExists := slices.ContainsFunc(shoot.Spec.Extensions, func(e gardener.Extension) bool {
 				return e.Type == ext.Type
 			})
 
-			if !existsInCurrent && gardenerExtension != nil {
-				shoot.Spec.Extensions = append(shoot.Spec.Extensions, *gardenerExtension)
+			if !alreadyExists && updatedGardenerExtension != nil {
+				shoot.Spec.Extensions = append(shoot.Spec.Extensions, *updatedGardenerExtension)
 			}
 
-			if existsInCurrent {
-				liveIndex := slices.IndexFunc(shoot.Spec.Extensions, func(e gardener.Extension) bool {
+			if alreadyExists {
+				index := slices.IndexFunc(shoot.Spec.Extensions, func(e gardener.Extension) bool {
 					return e.Type == ext.Type
 				})
-				if liveIndex != -1 {
-					if gardenerExtension != nil {
-						shoot.Spec.Extensions[liveIndex] = *gardenerExtension
+				if index != -1 {
+					if updatedGardenerExtension != nil {
+						shoot.Spec.Extensions[index] = *updatedGardenerExtension
 					} else if ext.Strategy == StrategyRemove {
-						shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, liveIndex, liveIndex+1)
+						shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, index, index+1)
 					}
 				}
 			}

--- a/pkg/gardener/shoot/extender/extensions/extender.go
+++ b/pkg/gardener/shoot/extender/extensions/extender.go
@@ -207,13 +207,10 @@ func newExtensionsExtender(extensionsToApply []Extension, currentGardenerExtensi
 			}
 
 			if index != -1 {
-
 				if gardenerExtension != nil {
 					shoot.Spec.Extensions[index] = *gardenerExtension
-				}
-
-				if ext.Strategy == StrategyRemove {
-					shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, index, index)
+				} else if ext.Strategy == StrategyRemove {
+					shoot.Spec.Extensions = slices.Delete(shoot.Spec.Extensions, index, index+1)
 				}
 			}
 		}

--- a/pkg/gardener/shoot/extender/extensions/extensions_extender_test.go
+++ b/pkg/gardener/shoot/extender/extensions/extensions_extender_test.go
@@ -816,6 +816,62 @@ func getExpectedExtensionsOrderMapForCreateWithNvidiaOpenshell() map[string]int 
 	return extensionOrderMap
 }
 
+func TestStrategyRemove(t *testing.T) {
+	const removedType = "to-be-removed"
+	const keptType = "kept"
+
+	existingExtensions := []gardener.Extension{
+		{Type: keptType},
+		{Type: removedType},
+	}
+
+	extender := newExtensionsExtender([]Extension{
+		{
+			Type: removedType,
+			Create: func(_ imv1.Runtime, _ gardener.Shoot) (*gardener.Extension, error) {
+				return nil, nil
+			},
+			Strategy: StrategyRemove,
+		},
+	}, existingExtensions)
+
+	shoot := &gardener.Shoot{}
+	err := extender(imv1.Runtime{}, shoot)
+	assert.NoError(t, err)
+	require.Len(t, shoot.Spec.Extensions, 1)
+	assert.Equal(t, keptType, shoot.Spec.Extensions[0].Type)
+}
+
+func TestStrategyRemoveDoesNotRemoveWhenExtensionReturnsNonNil(t *testing.T) {
+	const updatedType = "updated"
+	const keptType = "kept"
+
+	updated := &gardener.Extension{Type: updatedType, Disabled: ptr.To(false)}
+
+	existingExtensions := []gardener.Extension{
+		{Type: keptType},
+		{Type: updatedType, Disabled: ptr.To(true)},
+	}
+
+	extender := newExtensionsExtender([]Extension{
+		{
+			Type: updatedType,
+			Create: func(_ imv1.Runtime, _ gardener.Shoot) (*gardener.Extension, error) {
+				return updated, nil
+			},
+			Strategy: StrategyRemove,
+		},
+	}, existingExtensions)
+
+	shoot := &gardener.Shoot{}
+	err := extender(imv1.Runtime{}, shoot)
+	assert.NoError(t, err)
+	require.Len(t, shoot.Spec.Extensions, 2)
+	assert.Equal(t, keptType, shoot.Spec.Extensions[0].Type)
+	assert.Equal(t, updatedType, shoot.Spec.Extensions[1].Type)
+	assert.Equal(t, false, *shoot.Spec.Extensions[1].Disabled)
+}
+
 func buildFakeClientWithACLConfigMap(t *testing.T, configMapGetCalled *bool) client.Client {
 	ipData, err := os.ReadFile("testdata/config-map-ips.yaml")
 	require.NoError(t, err)

--- a/pkg/gardener/shoot/extender/extensions/extensions_extender_test.go
+++ b/pkg/gardener/shoot/extender/extensions/extensions_extender_test.go
@@ -237,6 +237,7 @@ func TestNewExtensionsExtenderForPatch(t *testing.T) {
 		enableNvidiaOpenshell *bool
 		providerType          string
 		expectedInternalDNS   bool
+		removedExtensionTypes []string
 	}{
 		{
 			name:                 "Should add AuditLog extension at the end without changing order and data of other extensions",
@@ -312,7 +313,7 @@ func TestNewExtensionsExtenderForPatch(t *testing.T) {
 		},
 		{
 			name:                 "Should update RegistryCache extension without changing order and data of other extensions",
-			previousExtensions:   fixAllExtensionsOnTheShoot(true),
+			previousExtensions:   []gardener.Extension{fixAuditLogExtensions(), fixDNSExtension(), fixCertExtension(), fixNetworkExtension(), fixOIDCExtensions()},
 			inputAuditLogData:    oldAuditLogData,
 			expectedAuditLogData: oldAuditLogData,
 			registryCaches:       newCaches,
@@ -327,12 +328,13 @@ func TestNewExtensionsExtenderForPatch(t *testing.T) {
 			enableNetworkFilter:  false,
 		},
 		{
-			name:                 "Should disable RegistryCache extension when cache is not enabled on Runtime CR without changing order and data of other extensions",
-			previousExtensions:   fixAllExtensionsOnTheShoot(true),
-			inputAuditLogData:    oldAuditLogData,
-			expectedAuditLogData: oldAuditLogData,
-			registryCaches:       []imv1.ImageRegistryCache{},
-			enableNetworkFilter:  false,
+			name:                  "Should remove RegistryCache extension when cache list is empty on Runtime CR without changing order and data of other extensions",
+			previousExtensions:    fixAllExtensionsOnTheShoot(true),
+			inputAuditLogData:     oldAuditLogData,
+			expectedAuditLogData:  oldAuditLogData,
+			registryCaches:        []imv1.ImageRegistryCache{},
+			enableNetworkFilter:   false,
+			removedExtensionTypes: []string{RegistryCacheExtensionType},
 		},
 		{
 			name:                 "Should not update existing AuditLog extension when input auditLogData is empty",
@@ -441,7 +443,7 @@ func TestNewExtensionsExtenderForPatch(t *testing.T) {
 			nvidiaOpenshellExistsInOutput := isNvidiaOpenshellEnabled(testRuntime) || existingExtension(NvidiaOpenshellExtensionType, prevShoot) != nil
 
 			extender := NewExtensionsExtenderForPatch(context.Background(), fakeClient, config, testCase.inputAuditLogData, testCase.previousExtensions, testCase.apiServerACLEnabled, map[string]string{})
-			orderMap := getExpectedExtensionsOrderMapForPatch(testCase.previousExtensions, testCase.enableNetworkFilter, auditLogDataProvided, registryCacheDataProvided, kubeApiServerACLEnabled, nvidiaOpenshellExistsInOutput)
+			orderMap := getExpectedExtensionsOrderMapForPatch(testCase.previousExtensions, testCase.enableNetworkFilter, auditLogDataProvided, registryCacheDataProvided, kubeApiServerACLEnabled, nvidiaOpenshellExistsInOutput, testCase.removedExtensionTypes)
 
 			err := extender(testRuntime, shoot)
 			assert.NoError(t, err)
@@ -588,11 +590,20 @@ func fixNvidiaOpenshellExtensionEnabled() gardener.Extension {
 	}
 }
 
-func getExpectedExtensionsOrderMapForPatch(previousExtensions []gardener.Extension, networkExtAdded bool, auditLogExtAdded bool, registryCacheExtAdded bool, kubeApiServerACLEnabled bool, nvidiaOpenshellInOutput bool) map[string]int {
-	extensionOrderMap := make(map[string]int)
+func getExpectedExtensionsOrderMapForPatch(previousExtensions []gardener.Extension, networkExtAdded bool, auditLogExtAdded bool, registryCacheExtAdded bool, kubeApiServerACLEnabled bool, nvidiaOpenshellInOutput bool, removedExtensionTypes []string) map[string]int {
+	removed := make(map[string]bool, len(removedExtensionTypes))
+	for _, t := range removedExtensionTypes {
+		removed[t] = true
+	}
 
-	for idx, ext := range previousExtensions {
+	extensionOrderMap := make(map[string]int)
+	idx := 0
+	for _, ext := range previousExtensions {
+		if removed[ext.Type] {
+			continue
+		}
 		extensionOrderMap[ext.Type] = idx
+		idx++
 	}
 
 	if auditLogExtAdded {

--- a/pkg/gardener/shoot/extender/extensions/registry_config.go
+++ b/pkg/gardener/shoot/extender/extensions/registry_config.go
@@ -19,10 +19,6 @@ func NewRegistryCacheExtension(caches []imv1.ImageRegistryCache, registryCacheGa
 		return extension(caches, registryCacheGardenSecretNames)
 	}
 
-	if existingRegistryCacheExt != nil {
-		return disabledExtension(existingRegistryCacheExt)
-	}
-
 	return nil, nil
 }
 
@@ -48,10 +44,6 @@ func extension(caches []imv1.ImageRegistryCache, registryCacheGardenSecretNames 
 		},
 		Disabled: ptr.To(false),
 	}, nil
-}
-
-func disabledExtension(_ *gardener.Extension) (*gardener.Extension, error) {
-	return nil, nil
 }
 
 func ToRegistryCacheExtension(caches []imv1.ImageRegistryCache, registryCacheGardenSecretNames map[string]string) []registrycacheext.RegistryCache {

--- a/pkg/gardener/shoot/extender/extensions/registry_config.go
+++ b/pkg/gardener/shoot/extender/extensions/registry_config.go
@@ -50,33 +50,8 @@ func extension(caches []imv1.ImageRegistryCache, registryCacheGardenSecretNames 
 	}, nil
 }
 
-func disabledExtension(existingRegistryCacheExt *gardener.Extension) (*gardener.Extension, error) {
-	var providerConfig registrycacheext.RegistryConfig
-
-	err := json.Unmarshal(existingRegistryCacheExt.ProviderConfig.Raw, &providerConfig)
-
-	if err != nil {
-		return nil, err
-	}
-
-	for i := 0; i < len(providerConfig.Caches); i++ {
-		providerConfig.Caches[i].SecretReferenceName = nil
-	}
-
-	providerConfigBytes, err := json.Marshal(providerConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// In case the extension is configured, and the user removes registry cache we disable the extension.
-	// In order to be able to remove registry credentials secret the reference to the secret name needs to be removed.
-	return &gardener.Extension{
-		Type: RegistryCacheExtensionType,
-		ProviderConfig: &runtime.RawExtension{
-			Raw: providerConfigBytes,
-		},
-		Disabled: ptr.To(true),
-	}, nil
+func disabledExtension(_ *gardener.Extension) (*gardener.Extension, error) {
+	return nil, nil
 }
 
 func ToRegistryCacheExtension(caches []imv1.ImageRegistryCache, registryCacheGardenSecretNames map[string]string) []registrycacheext.RegistryCache {

--- a/pkg/gardener/shoot/extender/extensions/registry_config_test.go
+++ b/pkg/gardener/shoot/extender/extensions/registry_config_test.go
@@ -16,6 +16,92 @@ import (
 
 func TestNewRegistryCacheExtension(t *testing.T) {
 
+	t.Run("should return nil when caches list is empty", func(t *testing.T) {
+		registryCacheExtension, err := NewRegistryCacheExtension([]imv1.ImageRegistryCache{}, nil, nil)
+
+		require.NoError(t, err)
+		require.Nil(t, registryCacheExtension)
+	})
+
+	t.Run("should return nil when caches is nil", func(t *testing.T) {
+		registryCacheExtension, err := NewRegistryCacheExtension(nil, nil, nil)
+
+		require.NoError(t, err)
+		require.Nil(t, registryCacheExtension)
+	})
+
+	t.Run("should omit secret reference when SecretReferenceName is nil", func(t *testing.T) {
+		caches := []imv1.ImageRegistryCache{
+			{
+				UID: "id1",
+				Config: registrycache.RegistryCacheConfigSpec{
+					Upstream:            "ghcr.io",
+					SecretReferenceName: nil,
+				},
+			},
+		}
+
+		registryCacheExtension, err := NewRegistryCacheExtension(caches, map[string]string{"id1": "garden-name-1"}, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, registryCacheExtension)
+
+		var providerConfig registrycacheext.RegistryConfig
+		err = yaml.Unmarshal(registryCacheExtension.ProviderConfig.Raw, &providerConfig)
+		require.NoError(t, err)
+
+		assert.Nil(t, providerConfig.Caches[0].SecretReferenceName)
+	})
+
+	t.Run("should omit secret reference when SecretReferenceName is empty string", func(t *testing.T) {
+		caches := []imv1.ImageRegistryCache{
+			{
+				UID: "id1",
+				Config: registrycache.RegistryCacheConfigSpec{
+					Upstream:            "ghcr.io",
+					SecretReferenceName: ptr.To(""),
+				},
+			},
+		}
+
+		registryCacheExtension, err := NewRegistryCacheExtension(caches, map[string]string{"id1": "garden-name-1"}, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, registryCacheExtension)
+
+		var providerConfig registrycacheext.RegistryConfig
+		err = yaml.Unmarshal(registryCacheExtension.ProviderConfig.Raw, &providerConfig)
+		require.NoError(t, err)
+
+		assert.Nil(t, providerConfig.Caches[0].SecretReferenceName)
+	})
+
+	t.Run("should create extension with all optional fields nil", func(t *testing.T) {
+		caches := []imv1.ImageRegistryCache{
+			{
+				Config: registrycache.RegistryCacheConfigSpec{
+					Upstream: "docker.io",
+				},
+			},
+		}
+
+		registryCacheExtension, err := NewRegistryCacheExtension(caches, nil, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, registryCacheExtension)
+
+		var providerConfig registrycacheext.RegistryConfig
+		err = yaml.Unmarshal(registryCacheExtension.ProviderConfig.Raw, &providerConfig)
+		require.NoError(t, err)
+
+		assert.Equal(t, "docker.io", providerConfig.Caches[0].Upstream)
+		assert.Nil(t, providerConfig.Caches[0].Volume)
+		assert.Nil(t, providerConfig.Caches[0].GarbageCollection)
+		assert.Nil(t, providerConfig.Caches[0].Proxy)
+		assert.Nil(t, providerConfig.Caches[0].SecretReferenceName)
+		assert.Nil(t, providerConfig.Caches[0].RemoteURL)
+	})
+
 	t.Run("should create registry cache extension", func(t *testing.T) {
 
 		// given


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Modified extensions extender to remove extensions from the list
- Registry Cache is removed from extensions list if not registry caches are configured

The changes prevent subtle bugs that cause Registry Cache Config to stuck in the `Pending` state.

Example scenario:
1. User configures Registry Cache config for some repository, the configuration doesn't include the volume settings
2. User removes the configuration
3. User adds a new config, but they include volume settings
4. Shoot update fails as the Gardener validations detects that immutable field (volume) was modified