### PR TITLE
Validate administrators to block Kubernetes built-in identities

### DIFF
--- a/.github/workflows/build_kim.yaml
+++ b/.github/workflows/build_kim.yaml
@@ -50,10 +50,11 @@ jobs:
       pr-tag: ${{ steps.pr-tag.outputs.pr-tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
       - id: tag
         if: github.event_name == 'push' && github.ref_type == 'tag'
         run: echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/daily-markdown-link-check.yaml
+++ b/.github/workflows/daily-markdown-link-check.yaml
@@ -8,7 +8,7 @@ jobs:
   daily-markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: gaurav-nelson/github-action-markdown-link-check@0524e79d8d7d1606112722dd7a3b5f5ce367de3e
         with:
           use-quiet-mode: 'yes'  

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,7 +14,7 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/pr-markdown-link-check.yaml
+++ b/.github/workflows/pr-markdown-link-check.yaml
@@ -5,7 +5,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: gaurav-nelson/github-action-markdown-link-check@0524e79d8d7d1606112722dd7a3b5f5ce367de3e
         with:
           use-quiet-mode: 'yes'  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: write  # Needed for creating releases and uploading assets
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
 ############################################################################################
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/api/v1/runtime_types.go
+++ b/api/v1/runtime_types.go
@@ -244,6 +244,10 @@ type Networking struct {
 	VPCNetwork *string `json:"vpcNetwork,omitempty"`
 }
 type Security struct {
+	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:items:MaxLength=253
+	// +kubebuilder:validation:XValidation:rule="self.all(admin, !admin.lowerAscii().startsWith('system:'))",message="administrator cannot start with 'system:' (Kubernetes built-in identity)"
+	// +kubebuilder:validation:XValidation:rule="self.all(admin, admin.trim() == admin && size(admin) > 0)",message="administrator cannot be empty or have leading/trailing whitespace"
 	Administrators []string           `json:"administrators"`
 	Networking     NetworkingSecurity `json:"networking"`
 }

--- a/config/crd/bases/infrastructuremanager.kyma-project.io_runtimes.yaml
+++ b/config/crd/bases/infrastructuremanager.kyma-project.io_runtimes.yaml
@@ -159,8 +159,18 @@ spec:
                 properties:
                   administrators:
                     items:
+                      maxLength: 253
                       type: string
+                    maxItems: 100
                     type: array
+                    x-kubernetes-validations:
+                    - message: administrator cannot start with 'system:' (Kubernetes
+                        built-in identity)
+                      rule: self.all(admin, !admin.lowerAscii().startsWith('system:'))
+                    - message: administrator cannot be empty or have leading/trailing
+                        whitespace
+                      rule: self.all(admin, admin.trim() == admin && size(admin) >
+                        0)
                   networking:
                     properties:
                       filter:

--- a/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
@@ -79,6 +79,17 @@ func validateAdministrators(admins []string) error {
 }
 
 func sFnApplyClusterRoleBindings(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
+	// Validate administrators before processing
+	if err := validateAdministrators(s.instance.Spec.Security.Administrators); err != nil {
+		s.instance.UpdateStateFailed(
+			imv1.ConditionTypeRuntimeConfigured,
+			imv1.ConditionReasonConfigurationErr,
+			fmt.Sprintf("invalid administrator: %s", err.Error()),
+		)
+		m.log.Error(err, "Invalid administrator configuration")
+		return updateStatusAndStopWithError(err)
+	}
+
 	runtimeClient, err := m.RuntimeClientGetter.Get(ctx, s.instance)
 	if err != nil {
 		s.instance.UpdateStatePending(
@@ -97,17 +108,6 @@ func sFnApplyClusterRoleBindings(ctx context.Context, m *fsm, s *systemState) (s
 		updateCRBApplyPending(&s.instance)
 		m.log.Info("Cannot list Cluster Role Bindings on shoot, scheduling for retry")
 		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
-	}
-
-	// Validate administrators before processing
-	if err := validateAdministrators(s.instance.Spec.Security.Administrators); err != nil {
-		s.instance.UpdateStateFailed(
-			imv1.ConditionTypeRuntimeConfigured,
-			imv1.ConditionReasonConfigurationErr,
-			fmt.Sprintf("invalid administrator: %s", err.Error()),
-		)
-		m.log.Error(err, "Invalid administrator configuration")
-		return updateStatusAndStopWithError(err)
 	}
 
 	removed := getRemoved(crbList.Items, s.instance.Spec.Security.Administrators)

--- a/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
@@ -2,7 +2,10 @@ package fsm
 
 import (
 	"context"
+	"fmt"
 	"slices"
+	"strings"
+	"unicode"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/log_level"
@@ -19,6 +22,61 @@ var (
 		"reconciler.kyma-project.io/managed-by": "infrastructure-manager",
 	}
 )
+
+const maxAdministratorLength = 253
+
+// blockedPrefixes contains prefixes that are not allowed for administrators.
+// All Kubernetes built-in identities start with "system:" and granting them
+// cluster-admin would be a security risk.
+var blockedPrefixes = []string{
+	"system:",
+}
+
+// validateAdministrator checks if an administrator string is valid.
+// It blocks:
+// - Empty or whitespace-only strings
+// - Strings with leading/trailing whitespace
+// - Strings exceeding 253 characters
+// - Strings containing control characters
+// - Kubernetes built-in identities (anything starting with "system:")
+func validateAdministrator(admin string) error {
+	if strings.TrimSpace(admin) == "" {
+		return fmt.Errorf("cannot be empty or whitespace-only")
+	}
+
+	if admin != strings.TrimSpace(admin) {
+		return fmt.Errorf("cannot have leading or trailing whitespace")
+	}
+
+	if len(admin) > maxAdministratorLength {
+		return fmt.Errorf("exceeds maximum length of %d characters", maxAdministratorLength)
+	}
+
+	for _, r := range admin {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("contains invalid control character")
+		}
+	}
+
+	adminLower := strings.ToLower(admin)
+	for _, prefix := range blockedPrefixes {
+		if strings.HasPrefix(adminLower, prefix) {
+			return fmt.Errorf("cannot start with '%s' (Kubernetes built-in identity)", prefix)
+		}
+	}
+
+	return nil
+}
+
+// validateAdministrators validates a list of administrator strings.
+func validateAdministrators(admins []string) error {
+	for i, admin := range admins {
+		if err := validateAdministrator(admin); err != nil {
+			return fmt.Errorf("administrator[%d] %q: %w", i, admin, err)
+		}
+	}
+	return nil
+}
 
 func sFnApplyClusterRoleBindings(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
 	runtimeClient, err := m.RuntimeClientGetter.Get(ctx, s.instance)
@@ -38,6 +96,18 @@ func sFnApplyClusterRoleBindings(ctx context.Context, m *fsm, s *systemState) (s
 	if err := runtimeClient.List(ctx, &crbList); err != nil {
 		updateCRBApplyPending(&s.instance)
 		m.log.Info("Cannot list Cluster Role Bindings on shoot, scheduling for retry")
+		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
+	}
+
+	// Validate administrators before processing
+	if err := validateAdministrators(s.instance.Spec.Security.Administrators); err != nil {
+		s.instance.UpdateStatePending(
+			imv1.ConditionTypeRuntimeConfigured,
+			imv1.ConditionReasonConfigurationErr,
+			metav1.ConditionFalse,
+			fmt.Sprintf("invalid administrator: %s", err.Error()),
+		)
+		m.log.Error(err, "Invalid administrator configuration")
 		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
 	}
 
@@ -117,7 +187,7 @@ func getRemoved(crbs []rbacv1.ClusterRoleBinding, admins []string) (removed []rb
 			continue
 		}
 
-		if crb.RoleRef.Kind != "ClusterRole" && crb.RoleRef.Name != "cluster-admin" {
+		if crb.RoleRef.Kind != "ClusterRole" || crb.RoleRef.Name != "cluster-admin" {
 			// cluster role binding is not admin
 			continue
 		}

--- a/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
@@ -48,7 +48,7 @@ func validateAdministrator(admin string) error {
 		return fmt.Errorf("cannot have leading or trailing whitespace")
 	}
 
-	if len(admin) > maxAdministratorLength {
+	if len([]rune(admin)) > maxAdministratorLength {
 		return fmt.Errorf("exceeds maximum length of %d characters", maxAdministratorLength)
 	}
 
@@ -101,14 +101,13 @@ func sFnApplyClusterRoleBindings(ctx context.Context, m *fsm, s *systemState) (s
 
 	// Validate administrators before processing
 	if err := validateAdministrators(s.instance.Spec.Security.Administrators); err != nil {
-		s.instance.UpdateStatePending(
+		s.instance.UpdateStateFailed(
 			imv1.ConditionTypeRuntimeConfigured,
 			imv1.ConditionReasonConfigurationErr,
-			metav1.ConditionFalse,
 			fmt.Sprintf("invalid administrator: %s", err.Error()),
 		)
 		m.log.Error(err, "Invalid administrator configuration")
-		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
+		return updateStatusAndStopWithError(err)
 	}
 
 	removed := getRemoved(crbList.Items, s.instance.Spec.Security.Administrators)

--- a/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
@@ -104,7 +104,7 @@ func sFnApplyClusterRoleBindings(ctx context.Context, m *fsm, s *systemState) (s
 	}
 	// list existing cluster role bindings
 	var crbList rbacv1.ClusterRoleBindingList
-	if err := runtimeClient.List(ctx, &crbList); err != nil {
+	if err = runtimeClient.List(ctx, &crbList); err != nil {
 		updateCRBApplyPending(&s.instance)
 		m.log.Info("Cannot list Cluster Role Bindings on shoot, scheduling for retry")
 		return updateStatusAndRequeueAfter(m.ControlPlaneRequeueDuration)
@@ -240,15 +240,15 @@ func getMissing(crbs []rbacv1.ClusterRoleBinding, admins []string) (missing []rb
 
 func toAdminClusterRoleBindingWithLabel(name string, key, value string) rbacv1.ClusterRoleBinding {
 	// initialize labels
-	labels := map[string]string{}
+	lbls := map[string]string{}
 	if key != "" {
-		labels[key] = value
+		lbls[key] = value
 	}
 	// build CRB
 	return rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "admin-",
-			Labels:       labels,
+			Labels:       lbls,
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:     rbacv1.UserKind,

--- a/internal/controller/runtime/fsm/runtime_fsm_apply_crb_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_apply_crb_test.go
@@ -151,6 +151,20 @@ var _ = Describe(`runtime_fsm_apply_crb`, Label("applyCRB"), func() {
 			},
 			expected: nil,
 		}),
+		Entry("should not remove CRB with non-cluster-admin role name", tcCRBData{
+			admins: []string{"test1"},
+			crbs: []rbacv1.ClusterRoleBinding{
+				toNonAdminClusterRoleBinding("test2", "view"),
+			},
+			expected: nil,
+		}),
+		Entry("should not remove CRB with Role kind instead of ClusterRole", tcCRBData{
+			admins: []string{"test1"},
+			crbs: []rbacv1.ClusterRoleBinding{
+				toRoleBindingNotClusterRole("test2"),
+			},
+			expected: nil,
+		}),
 	)
 
 	testRuntime := imv1.Runtime{
@@ -306,4 +320,16 @@ func toServiceAccountClusterRoleBinding(name string) rbacv1.ClusterRoleBinding {
 			Name:     "cluster-admin",
 		},
 	}
+}
+
+func toNonAdminClusterRoleBinding(name, roleName string) rbacv1.ClusterRoleBinding {
+	crb := toAdminClusterRoleBinding(name)
+	crb.RoleRef.Name = roleName
+	return crb
+}
+
+func toRoleBindingNotClusterRole(name string) rbacv1.ClusterRoleBinding {
+	crb := toAdminClusterRoleBinding(name)
+	crb.RoleRef.Kind = "Role"
+	return crb
 }

--- a/internal/controller/runtime/fsm/runtime_fsm_validate_administrators_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_validate_administrators_test.go
@@ -1,0 +1,151 @@
+package fsm
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("validateAdministrator", func() {
+	DescribeTable("should allow valid administrators",
+		func(admin string) {
+			err := validateAdministrator(admin)
+			Expect(err).ShouldNot(HaveOccurred())
+		},
+		// Email addresses
+		Entry("simple email", "user@example.com"),
+		Entry("email with dots", "first.last@example.com"),
+		Entry("email with plus", "user+tag@example.com"),
+		Entry("email with subdomain", "user@mail.example.com"),
+		Entry("SAP email", "john.doe@sap.com"),
+
+		// GitHub OIDC tokens
+		Entry("github pull_request", "github:repo:org/repo:pull_request"),
+		Entry("github push", "github:repo:org/repo:push"),
+		Entry("github ref", "github:repo:cx-commerce/cxmc-saastooling-kyma-charts:ref:refs/heads/main"),
+
+		// ArgoCD service accounts
+		Entry("argocd application-controller", "argocd:system:serviceaccount:sf-c6f4c9c3-2ead-4feb-810f-5be6ec043171:argocd-application-controller"),
+		Entry("argocd server", "argocd:system:serviceaccount:sf-c6f4c9c3-2ead-4feb-810f-5be6ec043171:argocd-server"),
+
+		// MCP service accounts
+		Entry("mcp helm-controller", "mcp:system:serviceaccount:flux-system:helm-controller"),
+		Entry("mcp kustomize-controller", "mcp:system:serviceaccount:flux-system:kustomize-controller"),
+		Entry("mcp provider-kubernetes", "mcp:system:serviceaccount:crossplane-system:provider-kubernetes"),
+
+		// Custom groups (not starting with system:)
+		Entry("custom group", "my-custom-group"),
+		Entry("custom group with dashes", "team-platform-admins"),
+	)
+
+	DescribeTable("should block dangerous system: prefixes",
+		func(admin string) {
+			err := validateAdministrator(admin)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("system:"))
+		},
+		Entry("system:anonymous", "system:anonymous"),
+		Entry("system:unauthenticated", "system:unauthenticated"),
+		Entry("system:authenticated", "system:authenticated"),
+		Entry("system:masters", "system:masters"),
+		Entry("system:nodes", "system:nodes"),
+		Entry("system:node:specific", "system:node:node-1"),
+		Entry("system:serviceaccount raw", "system:serviceaccount:kube-system:default"),
+		Entry("system:kube-controller-manager", "system:kube-controller-manager"),
+		Entry("system:kube-scheduler", "system:kube-scheduler"),
+		// Case insensitive
+		Entry("SYSTEM:MASTERS uppercase", "SYSTEM:MASTERS"),
+		Entry("System:Anonymous mixed case", "System:Anonymous"),
+	)
+
+	DescribeTable("should block malformed input",
+		func(admin string, expectedErr string) {
+			err := validateAdministrator(admin)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring(expectedErr))
+		},
+		Entry("empty string", "", "empty"),
+		Entry("whitespace only", "   ", "empty"),
+		Entry("tabs only", "\t\t", "empty"),
+		Entry("leading space", " user@example.com", "whitespace"),
+		Entry("trailing space", "user@example.com ", "whitespace"),
+		Entry("leading tab", "\tuser@example.com", "whitespace"),
+		Entry("contains newline", "user@example.com\nadmin", "control character"),
+		Entry("contains carriage return", "user@example.com\radmin", "control character"),
+		Entry("contains tab in middle", "user\t@example.com", "control character"),
+		Entry("contains null byte", "user\x00@example.com", "control character"),
+	)
+
+	It("should block strings exceeding max length", func() {
+		longAdmin := strings.Repeat("a", 254)
+		err := validateAdministrator(longAdmin)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).Should(ContainSubstring("exceeds maximum length"))
+	})
+
+	It("should allow strings at max length", func() {
+		maxLengthAdmin := strings.Repeat("a", 253)
+		err := validateAdministrator(maxLengthAdmin)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("validateAdministrators", func() {
+	It("should pass for empty list", func() {
+		err := validateAdministrators([]string{})
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("should pass for nil list", func() {
+		err := validateAdministrators(nil)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("should pass for valid administrators", func() {
+		admins := []string{
+			"user@example.com",
+			"github:repo:org/repo:pull_request",
+			"argocd:system:serviceaccount:ns:sa",
+		}
+		err := validateAdministrators(admins)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("should fail and report index for invalid administrator", func() {
+		admins := []string{
+			"valid@example.com",
+			"system:anonymous",
+			"another@example.com",
+		}
+		err := validateAdministrators(admins)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).Should(ContainSubstring("administrator[1]"))
+		Expect(err.Error()).Should(ContainSubstring("system:anonymous"))
+	})
+})
+
+func TestValidateAdministrator(t *testing.T) {
+	tests := []struct {
+		name    string
+		admin   string
+		wantErr bool
+	}{
+		{"valid email", "user@example.com", false},
+		{"valid github oidc", "github:repo:org/repo:pull_request", false},
+		{"valid argocd sa", "argocd:system:serviceaccount:ns:name", false},
+		{"valid mcp sa", "mcp:system:serviceaccount:ns:name", false},
+		{"blocked system:anonymous", "system:anonymous", true},
+		{"blocked system:masters", "system:masters", true},
+		{"blocked empty", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAdministrator(tt.admin)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAdministrator() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/controller/runtime/fsm/runtime_fsm_validate_administrators_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_validate_administrators_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fsm
 
 import (

--- a/internal/controller/runtime/runtime_controller_cel_validation_test.go
+++ b/internal/controller/runtime/runtime_controller_cel_validation_test.go
@@ -28,9 +28,11 @@ import (
 var _ = Describe("Runtime Administrator CEL Validation", func() {
 	ctx := context.Background()
 
+	var invalidAdminTestCounter int
 	DescribeTable("should reject Runtime with invalid administrators",
 		func(adminName string, expectedErrSubstring string) {
-			runtime := CreateRuntimeStub("test-cel-validation")
+			invalidAdminTestCounter++
+			runtime := CreateRuntimeStub(fmt.Sprintf("test-cel-invalid-%d", invalidAdminTestCounter))
 			runtime.Spec.Security.Administrators = []string{adminName}
 
 			err := k8sClient.Create(ctx, runtime)

--- a/internal/controller/runtime/runtime_controller_cel_validation_test.go
+++ b/internal/controller/runtime/runtime_controller_cel_validation_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var _ = Describe("Runtime Administrator CEL Validation", func() {
+	ctx := context.Background()
+
+	DescribeTable("should reject Runtime with invalid administrators",
+		func(adminName string, expectedErrSubstring string) {
+			runtime := CreateRuntimeStub("test-cel-validation")
+			runtime.Spec.Security.Administrators = []string{adminName}
+
+			err := k8sClient.Create(ctx, runtime)
+			Expect(err).To(HaveOccurred())
+			Expect(k8serrors.IsInvalid(err)).To(BeTrue(), "expected Invalid error, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring(expectedErrSubstring))
+		},
+		// system: prefix tests (should be blocked)
+		Entry("system:anonymous", "system:anonymous", "system:"),
+		Entry("system:authenticated", "system:authenticated", "system:"),
+		Entry("system:unauthenticated", "system:unauthenticated", "system:"),
+		Entry("system:masters", "system:masters", "system:"),
+		Entry("system:nodes", "system:nodes", "system:"),
+		Entry("system:serviceaccount:kube-system:default", "system:serviceaccount:kube-system:default", "system:"),
+		Entry("SYSTEM:MASTERS (case insensitive)", "SYSTEM:MASTERS", "system:"),
+		Entry("System:Anonymous (mixed case)", "System:Anonymous", "system:"),
+
+		// Empty/whitespace tests
+		Entry("empty string", "", "empty"),
+		Entry("whitespace only", "   ", "empty"),
+		Entry("leading space", " user@example.com", "whitespace"),
+		Entry("trailing space", "user@example.com ", "whitespace"),
+	)
+
+	var validAdminTestCounter int
+	DescribeTable("should accept Runtime with valid administrators",
+		func(adminName string) {
+			validAdminTestCounter++
+			runtime := CreateRuntimeStub(fmt.Sprintf("test-cel-valid-%d", validAdminTestCounter))
+			runtime.Spec.Security.Administrators = []string{adminName}
+
+			err := k8sClient.Create(ctx, runtime)
+			Expect(err).NotTo(HaveOccurred(), "expected no error for admin %q, got: %v", adminName, err)
+
+			// Cleanup
+			_ = k8sClient.Delete(ctx, runtime)
+		},
+		// Valid email addresses
+		Entry("simple email", "user@example.com"),
+		Entry("email with dots", "first.last@example.com"),
+
+		// Valid service accounts with trusted prefixes
+		Entry("argocd service account", "argocd:system:serviceaccount:ns:sa"),
+		Entry("mcp service account", "mcp:system:serviceaccount:flux-system:helm-controller"),
+		Entry("github OIDC", "github:repo:org/repo:pull_request"),
+
+		// Custom groups (not starting with system:)
+		Entry("custom group", "my-custom-group"),
+		Entry("group with dashes", "team-platform-admins"),
+	)
+
+	It("should reject Runtime when administrators list exceeds max length", func() {
+		runtime := CreateRuntimeStub("test-cel-length")
+		// Create a string longer than 253 characters
+		longAdmin := make([]byte, 254)
+		for i := range longAdmin {
+			longAdmin[i] = 'a'
+		}
+		runtime.Spec.Security.Administrators = []string{string(longAdmin)}
+
+		err := k8sClient.Create(ctx, runtime)
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsInvalid(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("Too long"))
+	})
+
+	It("should accept Runtime when administrator is exactly at max length", func() {
+		runtime := CreateRuntimeStub("test-cel-max-length")
+		// Create a string exactly 253 characters
+		maxLengthAdmin := make([]byte, 253)
+		for i := range maxLengthAdmin {
+			maxLengthAdmin[i] = 'a'
+		}
+		runtime.Spec.Security.Administrators = []string{string(maxLengthAdmin)}
+
+		err := k8sClient.Create(ctx, runtime)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Cleanup
+		_ = k8sClient.Delete(ctx, runtime)
+	})
+
+	It("should reject Runtime when one admin in list is invalid", func() {
+		runtime := CreateRuntimeStub("test-cel-mixed")
+		runtime.Spec.Security.Administrators = []string{
+			"valid@example.com",
+			"system:masters", // invalid
+			"another@example.com",
+		}
+
+		err := k8sClient.Create(ctx, runtime)
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsInvalid(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("system:"))
+	})
+})


### PR DESCRIPTION
## Summary
- Add input validation for `Runtime.Spec.Security.Administrators` to prevent granting cluster-admin privileges to dangerous Kubernetes built-in identities
- Blocks all `system:*` patterns (system:anonymous, system:masters, system:authenticated, etc.)
- Adds CRD-level CEL validation and controller-level defense-in-depth validation
- Upgrade of used checkout gh action to version v7 with `allow-unsafe-pr-checkout` flag


Addresses: internal-kyma-repo/issues/10113

## Test plan
- [x] Unit tests for validation logic
- [x] Integration tests with envtest for CEL validation
- [x] `make test` passes