### PR TITLE
Fix dedicated auditlog patch

### DIFF
--- a/docs/adr/006-enable-dedicated-auditlog-for-existing-runtimes-implementation.md
+++ b/docs/adr/006-enable-dedicated-auditlog-for-existing-runtimes-implementation.md
@@ -77,7 +77,7 @@ func resolveAuditLogData(ctx context.Context, m *fsm, s *systemState) (auditlogs
             m.log.Info("Dedicated audit logging is irreversible - ignoring attempt to disable",
                 "runtimeID", runtimeID)
         }
-        return toExtenderAuditLogData(existingData), nil, nil, nil
+        return toExtenderAuditLogData(existingData, true), nil, nil, nil
     }
 
     // Runtime flag not set → use shared config
@@ -117,7 +117,7 @@ func getSharedAuditLogDataWithErrorHandling(ctx context.Context, m *fsm, s *syst
         }
     }
 
-    return toExtenderAuditLogData(data), nil, nil, err
+    return toExtenderAuditLogData(data, false), nil, nil, err
 }
 ```
 
@@ -161,7 +161,7 @@ func claimDedicatedAuditLog(ctx context.Context, m *fsm, s *systemState, runtime
         "Dedicated audit logging claimed, configuring shoot",
     )
 
-    return toExtenderAuditLogData(data), nil, nil, nil
+    return toExtenderAuditLogData(data, true), nil, nil, nil
 }
 ```
 
@@ -170,12 +170,14 @@ func claimDedicatedAuditLog(ctx context.Context, m *fsm, s *systemState, runtime
 Converts between package types:
 
 ```go
-// toExtenderAuditLogData converts auditlog.AuditLogData to extender auditlogs.AuditLogData
-func toExtenderAuditLogData(data auditlog.AuditLogData) auditlogs.AuditLogData {
+// toExtenderAuditLogData converts auditlog.AuditLogData to extender auditlogs.AuditLogData.
+// Dedicated data selects the dedicated secret reference; shared data selects the shared reference.
+func toExtenderAuditLogData(data auditlog.AuditLogData, dedicated bool) auditlogs.AuditLogData {
     return auditlogs.AuditLogData{
         TenantID:   data.TenantID,
         ServiceURL: data.ServiceURL,
         SecretName: data.SecretName,
+        Dedicated:  dedicated,
     }
 }
 ```
@@ -304,7 +306,7 @@ No changes needed to `sFnMigrateToDedicatedAuditLog`.
 
 Runtimes created in regions without shared audit log configuration had no audit log secret reference in `shoot.spec.resources`. When upgrading to dedicated audit logging, the Gardener `shoot-auditlog-service` extension would fail because:
 
-1. The extension expects a secret reference named `auditlog-credentials` in `shoot.spec.resources`
+1. The extension expects a secret reference whose name matches the audit logging mode in `shoot.spec.resources`: `auditlog-credentials` for shared logging or `dedicated-auditlog-credentials` for dedicated logging
 2. The converter was using `NewAuditlogExtenderForPatch` which **only updated the policy configmap**
 3. The secret reference was never added, causing the extension to fail
 
@@ -356,7 +358,7 @@ func NewAuditlogExtender(policyConfigMapName string, data AuditLogData) Extend {
     return func(rt imv1.Runtime, shoot *gardener.Shoot) error {
         policyConfigMapName := fixPolicyConfigMapName(rt.Annotations, policyConfigMapName)
         for _, f := range []operation{
-            oSetSecret(data.SecretName),           // ← Adds/updates secret reference
+            oSetSecret(data.SecretReferenceName(), data.SecretName),
             oSetPolicyConfigmap(policyConfigMapName), // ← Adds/updates policy
         } {
             if err := f(shoot); err != nil {
@@ -372,7 +374,7 @@ func NewAuditlogExtender(policyConfigMapName string, data AuditLogData) Extend {
 1. **Secret reference** in `shoot.spec.resources`:
    ```yaml
    resources:
-     - name: auditlog-credentials
+     - name: dedicated-auditlog-credentials  # Shared mode uses auditlog-credentials
        resourceRef:
          name: dedicated-audit-secret  # From AuditLogData.SecretName
          kind: Secret
@@ -395,20 +397,37 @@ func NewAuditlogExtender(policyConfigMapName string, data AuditLogData) Extend {
 
 Both operations are idempotent and safe to call repeatedly:
 
-**`oSetSecret` (set_secret.go:12-34)**:
+**`oSetSecret` (set_secret.go:10-41)**:
 ```go
-func oSetSecret(secretName string) operation {
+func oSetSecret(referenceName, secretName string) operation {
     return func(s *gardener.Shoot) error {
-        // Check if secret reference already exists
-        index := slices.IndexFunc(s.Spec.Resources, func(r gardener.NamedResourceReference) bool {
-            return r.Name == auditlogSecretReference
-        })
-        
-        if index == -1 {
-            s.Spec.Resources = append(s.Spec.Resources, resource) // Add new
-        } else {
-            s.Spec.Resources[index] = resource  // Update existing
+        otherReferenceName := SharedAuditlogSecretReference
+        if referenceName == SharedAuditlogSecretReference {
+            otherReferenceName = DedicatedAuditlogSecretReference
         }
+
+        s.Spec.Resources = slices.DeleteFunc(s.Spec.Resources, func(r gardener.NamedResourceReference) bool {
+            return r.Name == otherReferenceName
+        })
+
+        resource := gardener.NamedResourceReference{
+            Name: referenceName,
+            ResourceRef: v1.CrossVersionObjectReference{
+                Name:       secretName,
+                Kind:       "Secret",
+                APIVersion: "v1",
+            },
+        }
+        index := slices.IndexFunc(s.Spec.Resources, func(r gardener.NamedResourceReference) bool {
+            return r.Name == referenceName
+        })
+
+        if index == -1 {
+            s.Spec.Resources = append(s.Spec.Resources, resource)
+            return nil
+        }
+
+        s.Spec.Resources[index] = resource
         return nil
     }
 }
@@ -438,10 +457,10 @@ func oSetPolicyConfigmap(policyConfigMapName string) operation {
 | Scenario | Old Behavior (`ForPatch`) | New Behavior (`Full`) | Status |
 |----------|---------------------------|----------------------|--------|
 | **Normal patch (secret exists)** | Policy updated only | Secret + Policy updated | ✅ Safe - idempotent update |
-| **Upgrade: shared → dedicated** | Policy updated, secret unchanged | Secret + Policy updated to new values | ✅ **Improvement** |
+| **Upgrade: shared → dedicated** | Policy updated, secret unchanged | Dedicated secret + Policy updated; stale shared reference removed | ✅ **FIXED** |
 | **Upgrade: no auditlog → dedicated** | Policy updated, **secret missing** 🔴 | Secret + Policy both added | ✅ **FIXED** |
-| **Secret name changes (rotation)** | Secret NOT updated | Secret updated | ✅ **Improvement** |
-| **Idempotent calls** | Policy updated | Secret + Policy updated | ✅ Safe |
+| **Secret name changes (rotation)** | Secret NOT updated | Selected secret reference updated | ✅ **Improvement** |
+| **Repeated mode-consistent calls** | Policy updated | Selected secret + Policy updated; opposite reference removed | ✅ Safe |
 
 🔴 = Bug fixed by this change
 

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/kyma-project/infrastructure-manager/pkg/auditlog"
+	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/auditlogs"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/extensions"
 	v1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,8 +17,8 @@ import (
 )
 
 const (
-	auditlogSecretReference          = "auditlog-credentials"
-	dedicatedAuditlogSecretReference = "dedicated-auditlog-credentials"
+	auditlogSecretReference          = auditlogs.SharedAuditlogSecretReference
+	dedicatedAuditlogSecretReference = auditlogs.DedicatedAuditlogSecretReference
 )
 
 // patchShootAuditLog patches the shoot with dedicated audit log configuration.

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers.go
@@ -15,7 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const dedicatedAuditlogSecretReference = "dedicated-auditlog-credentials"
+const (
+	auditlogSecretReference          = "auditlog-credentials"
+	dedicatedAuditlogSecretReference = "dedicated-auditlog-credentials"
+)
 
 // patchShootAuditLog patches the shoot with dedicated audit log configuration.
 // It delegates all data mutations to applyDedicatedAuditLogToShoot and then
@@ -73,6 +76,10 @@ func updateAuditLogExtensionConfig(shoot *gardener.Shoot, auditLogData auditlog.
 // upsertAuditLogSecretReference adds or updates the NamedResourceReference that maps
 // dedicatedAuditlogSecretReference to the actual Gardener secret.
 func upsertAuditLogSecretReference(shoot *gardener.Shoot, secretName string) {
+	shoot.Spec.Resources = slices.DeleteFunc(shoot.Spec.Resources, func(r gardener.NamedResourceReference) bool {
+		return r.Name == auditlogSecretReference
+	})
+
 	resource := gardener.NamedResourceReference{
 		Name: dedicatedAuditlogSecretReference,
 		ResourceRef: v1.CrossVersionObjectReference{

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers_test.go
@@ -16,8 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-const auditlogCredentialsResource = "auditlog-credentials"
-
 func TestPatchShootAuditLog(t *testing.T) {
 	t.Run("should update audit log extension and add resource reference", func(t *testing.T) {
 		// given

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers_test.go
@@ -3,6 +3,7 @@ package fsm
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"testing"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -14,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+const auditlogCredentialsResource = "auditlog-credentials"
 
 func TestPatchShootAuditLog(t *testing.T) {
 	t.Run("should update audit log extension and add resource reference", func(t *testing.T) {
@@ -30,7 +33,7 @@ func TestPatchShootAuditLog(t *testing.T) {
 			Type:                "standard",
 			TenantID:            "old-tenant-id",
 			ServiceURL:          "https://old.example.com",
-			SecretReferenceName: "auditlog-credentials",
+			SecretReferenceName: auditlogCredentialsResource,
 		}
 		configJSON, _ := json.Marshal(existingConfig)
 
@@ -50,7 +53,7 @@ func TestPatchShootAuditLog(t *testing.T) {
 				},
 				Resources: []gardener.NamedResourceReference{
 					{
-						Name: "auditlog-credentials",
+						Name: auditlogCredentialsResource,
 						ResourceRef: v1.CrossVersionObjectReference{
 							Name:       "old-secret",
 							Kind:       "Secret",
@@ -307,6 +310,91 @@ func TestPatchShootAuditLog(t *testing.T) {
 		require.Len(t, systemState.shoot.Spec.Resources, 1)
 		require.Equal(t, dedicatedAuditlogSecretReference, systemState.shoot.Spec.Resources[0].Name)
 		require.Equal(t, "test-gardener-secret", systemState.shoot.Spec.Resources[0].ResourceRef.Name)
+	})
+
+	t.Run("should remove stale shared auditlog-credentials resource entry when migrating to dedicated", func(t *testing.T) {
+		// given
+		const expectedSecretName = "new-dedicated-secret"
+		ctx := context.Background()
+		auditLogData := auditlog.AuditLogData{
+			TenantID:   "test-tenant-id",
+			ServiceURL: "https://test.auditlog.example.com",
+			SecretName: expectedSecretName,
+		}
+
+		existingConfig := extensions.AuditlogExtensionConfig{
+			Type:                "standard",
+			TenantID:            "old-tenant-id",
+			ServiceURL:          "https://old.example.com",
+			SecretReferenceName: auditlogCredentialsResource,
+		}
+		configJSON, _ := json.Marshal(existingConfig)
+
+		shoot := &gardener.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-shoot",
+				Namespace: "garden-test",
+			},
+			Spec: gardener.ShootSpec{
+				Extensions: []gardener.Extension{
+					{
+						Type: extensions.AuditlogExtensionType,
+						ProviderConfig: &runtime.RawExtension{
+							Raw: configJSON,
+						},
+					},
+				},
+				Resources: []gardener.NamedResourceReference{
+					{
+						Name: auditlogCredentialsResource,
+						ResourceRef: v1.CrossVersionObjectReference{
+							Name:       "old-shared-secret",
+							Kind:       "Secret",
+							APIVersion: "v1",
+						},
+					},
+				},
+			},
+		}
+
+		scheme, _ := newCreateTestScheme()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shoot).Build()
+
+		testFsm := &fsm{
+			K8s: K8s{
+				GardenClient: fakeClient,
+			},
+		}
+
+		systemState := &systemState{
+			shoot: shoot,
+		}
+
+		// when
+		err := patchShootAuditLog(ctx, testFsm, systemState, auditLogData)
+
+		// then
+		require.NoError(t, err)
+
+		// Verify audit log extension configuration
+		require.Len(t, systemState.shoot.Spec.Extensions, 1)
+		ext := systemState.shoot.Spec.Extensions[0]
+		require.Equal(t, extensions.AuditlogExtensionType, ext.Type)
+
+		var updatedConfig extensions.AuditlogExtensionConfig
+		err = json.Unmarshal(ext.ProviderConfig.Raw, &updatedConfig)
+		require.NoError(t, err)
+		require.Equal(t, dedicatedAuditlogSecretReference, updatedConfig.SecretReferenceName)
+
+		// Verify stale shared auditlog-credentials resource entry was removed and only dedicated reference remains
+		require.Len(t, systemState.shoot.Spec.Resources, 1)
+		require.Equal(t, dedicatedAuditlogSecretReference, systemState.shoot.Spec.Resources[0].Name)
+		require.Equal(t, expectedSecretName, systemState.shoot.Spec.Resources[0].ResourceRef.Name)
+
+		sharedIndex := slices.IndexFunc(systemState.shoot.Spec.Resources, func(r gardener.NamedResourceReference) bool {
+			return r.Name == auditlogCredentialsResource
+		})
+		require.Equal(t, -1, sharedIndex, "stale auditlog-credentials resource entry should have been removed")
 	})
 }
 

--- a/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers_test.go
@@ -33,7 +33,7 @@ func TestPatchShootAuditLog(t *testing.T) {
 			Type:                "standard",
 			TenantID:            "old-tenant-id",
 			ServiceURL:          "https://old.example.com",
-			SecretReferenceName: auditlogCredentialsResource,
+			SecretReferenceName: auditlogSecretReference,
 		}
 		configJSON, _ := json.Marshal(existingConfig)
 
@@ -53,7 +53,7 @@ func TestPatchShootAuditLog(t *testing.T) {
 				},
 				Resources: []gardener.NamedResourceReference{
 					{
-						Name: auditlogCredentialsResource,
+						Name: auditlogSecretReference,
 						ResourceRef: v1.CrossVersionObjectReference{
 							Name:       "old-secret",
 							Kind:       "Secret",
@@ -96,8 +96,8 @@ func TestPatchShootAuditLog(t *testing.T) {
 		require.Equal(t, dedicatedAuditlogSecretReference, updatedConfig.SecretReferenceName)
 		require.Equal(t, "standard", updatedConfig.Type)
 
-		// Verify the resource reference was added
-		require.Len(t, systemState.shoot.Spec.Resources, 2)
+		// Verify the resource reference was added and stale shared reference was removed
+		require.Len(t, systemState.shoot.Spec.Resources, 1)
 
 		// Find the dedicated audit log resource reference
 		var dedicatedResource *gardener.NamedResourceReference
@@ -326,7 +326,7 @@ func TestPatchShootAuditLog(t *testing.T) {
 			Type:                "standard",
 			TenantID:            "old-tenant-id",
 			ServiceURL:          "https://old.example.com",
-			SecretReferenceName: auditlogCredentialsResource,
+			SecretReferenceName: auditlogSecretReference,
 		}
 		configJSON, _ := json.Marshal(existingConfig)
 
@@ -346,7 +346,7 @@ func TestPatchShootAuditLog(t *testing.T) {
 				},
 				Resources: []gardener.NamedResourceReference{
 					{
-						Name: auditlogCredentialsResource,
+						Name: auditlogSecretReference,
 						ResourceRef: v1.CrossVersionObjectReference{
 							Name:       "old-shared-secret",
 							Kind:       "Secret",
@@ -392,7 +392,7 @@ func TestPatchShootAuditLog(t *testing.T) {
 		require.Equal(t, expectedSecretName, systemState.shoot.Spec.Resources[0].ResourceRef.Name)
 
 		sharedIndex := slices.IndexFunc(systemState.shoot.Spec.Resources, func(r gardener.NamedResourceReference) bool {
-			return r.Name == auditlogCredentialsResource
+			return r.Name == auditlogSecretReference
 		})
 		require.Equal(t, -1, sharedIndex, "stale auditlog-credentials resource entry should have been removed")
 	})

--- a/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
@@ -326,7 +326,7 @@ func resolveAuditLogData(ctx context.Context, m *fsm, s *systemState) (auditlogs
 			m.log.Info("Dedicated audit logging is irreversible - ignoring attempt to disable",
 				"runtimeID", runtimeID)
 		}
-		return toExtenderAuditLogData(existingData), nil, nil, nil
+		return toExtenderAuditLogData(existingData, true), nil, nil, nil
 	}
 
 	if !s.instance.IsDedicatedAuditLogEnabled() {
@@ -358,7 +358,7 @@ func getSharedAuditLogDataWithErrorHandling(ctx context.Context, m *fsm, s *syst
 		}
 	}
 
-	return toExtenderAuditLogData(data), nil, nil, err
+	return toExtenderAuditLogData(data, false), nil, nil, err
 }
 
 // claimDedicatedAuditLog claims an AuditLogCR for upgrade scenario
@@ -396,7 +396,7 @@ func claimDedicatedAuditLog(ctx context.Context, m *fsm, s *systemState, runtime
 		"Dedicated audit logging claimed, configuring shoot",
 	)
 
-	return toExtenderAuditLogData(data), nil, nil, nil
+	return toExtenderAuditLogData(data, true), nil, nil, nil
 }
 
 func setRegistryCacheStatusFailed(ctx context.Context, m *fsm, s *systemState) {
@@ -412,10 +412,11 @@ func setRegistryCacheStatusFailed(ctx context.Context, m *fsm, s *systemState) {
 }
 
 // toExtenderAuditLogData converts auditlog.AuditLogData to extender auditlogs.AuditLogData
-func toExtenderAuditLogData(data auditlog.AuditLogData) auditlogs.AuditLogData {
+func toExtenderAuditLogData(data auditlog.AuditLogData, dedicated bool) auditlogs.AuditLogData {
 	return auditlogs.AuditLogData{
 		TenantID:   data.TenantID,
 		ServiceURL: data.ServiceURL,
 		SecretName: data.SecretName,
+		Dedicated:  dedicated,
 	}
 }

--- a/pkg/gardener/shoot/converter_test.go
+++ b/pkg/gardener/shoot/converter_test.go
@@ -322,6 +322,7 @@ func TestConverter(t *testing.T) {
 			TenantID:   "new-tenant-id",
 			ServiceURL: "https://new.auditlog.example.com",
 			SecretName: expectedSecretName,
+			Dedicated:  true,
 		}
 
 		converter := NewConverterPatch(context.Background(), PatchOpts{

--- a/pkg/gardener/shoot/converter_test.go
+++ b/pkg/gardener/shoot/converter_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/auditlogs"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/extender/extensions"
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/hyperscaler/aws"
+	v1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
@@ -21,7 +24,6 @@ import (
 	"github.com/kyma-project/infrastructure-manager/pkg/gardener/shoot/hyperscaler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConverter(t *testing.T) {
@@ -286,6 +288,79 @@ func TestConverter(t *testing.T) {
 
 		assert.Equal(t, expectedMaintenanceWindow, shoot.Spec.Maintenance.TimeWindow)
 	})
+
+	t.Run("Patch shoot already migrated to dedicated audit logging should not revert to shared secret reference name", func(t *testing.T) {
+		// given
+		const auditlogCredentialsRes = "auditlog-credentials"
+		const dedicatedAuditlogCredentialsRes = "dedicated-auditlog-credentials"
+		const expectedSecretName = "new-dedicated-secret"
+		runtime := fixRuntime(gardener.ShootPurposeProduction)
+		converterConfig := fixConverterConfig()
+
+		dedicatedExtensions := fixAllExtensionsOnTheShootWithDedicatedAuditLog()
+
+		resources := []gardener.NamedResourceReference{
+			{
+				Name: auditlogCredentialsRes,
+				ResourceRef: v1.CrossVersionObjectReference{
+					Name:       "old-shared-secret",
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			},
+			{
+				Name: dedicatedAuditlogCredentialsRes,
+				ResourceRef: v1.CrossVersionObjectReference{
+					Name:       "old-dedicated-secret",
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			},
+		}
+
+		auditLogData := auditlogs.AuditLogData{
+			TenantID:   "new-tenant-id",
+			ServiceURL: "https://new.auditlog.example.com",
+			SecretName: expectedSecretName,
+		}
+
+		converter := NewConverterPatch(context.Background(), PatchOpts{
+			ConverterConfig:      converterConfig,
+			Workers:              fixWorkersWithReversedZones("gardenlinux", "1591.1.0"),
+			ShootK8SVersion:      "1.28",
+			Extensions:           dedicatedExtensions,
+			Resources:            resources,
+			AuditLogData:         auditLogData,
+			InfrastructureConfig: fixAWSInfrastructureConfig("10.250.0.0/16", []string{"eu-central-1a"}),
+			ControlPlaneConfig:   fixAWSControlPlaneConfig(),
+		})
+
+		// when
+		shoot, err := converter.ToShoot(runtime)
+
+		// then
+		require.NoError(t, err)
+
+		extIdx := slices.IndexFunc(shoot.Spec.Extensions, func(ext gardener.Extension) bool {
+			return ext.Type == extensions.AuditlogExtensionType
+		})
+		require.NotEqual(t, -1, extIdx, "extension %s not found", extensions.AuditlogExtensionType)
+
+		var auditlogConfig extensions.AuditlogExtensionConfig
+		require.NoError(t, json.Unmarshal(shoot.Spec.Extensions[extIdx].ProviderConfig.Raw, &auditlogConfig))
+		assert.Equal(t, dedicatedAuditlogCredentialsRes, auditlogConfig.SecretReferenceName)
+
+		resIdx := slices.IndexFunc(shoot.Spec.Resources, func(res gardener.NamedResourceReference) bool {
+			return res.Name == dedicatedAuditlogCredentialsRes
+		})
+		require.NotEqual(t, -1, resIdx, "resource reference dedicated-auditlog-credentials not found")
+		assert.Equal(t, expectedSecretName, shoot.Spec.Resources[resIdx].ResourceRef.Name)
+
+		staleResIdx := slices.IndexFunc(shoot.Spec.Resources, func(res gardener.NamedResourceReference) bool {
+			return res.Name == auditlogCredentialsRes
+		})
+		assert.Equal(t, -1, staleResIdx, "stale resource reference auditlog-credentials should not be present")
+	})
 }
 
 func assertShootFields(t *testing.T, runtime imv1.Runtime, shoot gardener.Shoot) {
@@ -384,6 +459,17 @@ func fixAllExtensionsOnTheShoot() []gardener.Extension {
 	}
 }
 
+func fixAllExtensionsOnTheShootWithDedicatedAuditLog() []gardener.Extension {
+	exts := fixAllExtensionsOnTheShoot()
+	auditLogIdx := slices.IndexFunc(exts, func(ext gardener.Extension) bool {
+		return ext.Type == extensions.AuditlogExtensionType
+	})
+	exts[auditLogIdx].ProviderConfig = &runtime.RawExtension{
+		Raw: []byte(`{"apiVersion":"service.auditlog.extensions.gardener.cloud/v1alpha1","kind":"AuditlogConfig","type":"standard","tenantID":"test-auditlog-tenant","serviceURL":"test-auditlog-service-url","secretReferenceName":"dedicated-auditlog-credentials"}`),
+	}
+	return exts
+}
+
 func fixAWSInfrastructureConfig(workersCIDR string, zones []string) *runtime.RawExtension {
 	infraConfig, _ := aws.GetInfrastructureConfig(workersCIDR, zones)
 	return &runtime.RawExtension{Raw: infraConfig}
@@ -403,7 +489,7 @@ func fixRuntime(purpose gardener.ShootPurpose) imv1.Runtime {
 	imageVersion := "1591.1.0"
 
 	return imv1.Runtime{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "runtime",
 			Namespace: "kcp-system",
 		},
@@ -472,7 +558,7 @@ func fixRuntimeWithNoVersionsSpecified() imv1.Runtime {
 	usernameClaim := "sub"
 
 	return imv1.Runtime{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "runtime",
 			Namespace: "kcp-system",
 		},

--- a/pkg/gardener/shoot/extender/auditlogs/auditlogs_configuration.go
+++ b/pkg/gardener/shoot/extender/auditlogs/auditlogs_configuration.go
@@ -19,7 +19,9 @@ type AuditLogData struct {
 	TenantID   string `json:"tenantID" validate:"required"`
 	ServiceURL string `json:"serviceURL" validate:"required,url"`
 	SecretName string `json:"secretName" validate:"required"`
-	Dedicated  bool   `json:"dedicated,omitempty"`
+	// Dedicated is set internally to select the correct secret reference name; it is never
+	// (un)marshalled from/to the shared audit log configuration file.
+	Dedicated bool `json:"-"`
 }
 
 // SecretReferenceName returns the name under which the audit log secret should be

--- a/pkg/gardener/shoot/extender/auditlogs/auditlogs_configuration.go
+++ b/pkg/gardener/shoot/extender/auditlogs/auditlogs_configuration.go
@@ -6,6 +6,11 @@ var (
 	ErrConfigurationNotFound = fmt.Errorf("audit logs configuration not found")
 )
 
+const (
+	SharedAuditlogSecretReference    = "auditlog-credentials"
+	DedicatedAuditlogSecretReference = "dedicated-auditlog-credentials"
+)
+
 type region = string
 
 type providerType = string
@@ -14,6 +19,17 @@ type AuditLogData struct {
 	TenantID   string `json:"tenantID" validate:"required"`
 	ServiceURL string `json:"serviceURL" validate:"required,url"`
 	SecretName string `json:"secretName" validate:"required"`
+	Dedicated  bool   `json:"dedicated,omitempty"`
+}
+
+// SecretReferenceName returns the name under which the audit log secret should be
+// referenced in shoot.spec.resources and in the extension's providerConfig,
+// depending on whether this is shared or dedicated audit log configuration.
+func (d AuditLogData) SecretReferenceName() string {
+	if d.Dedicated {
+		return DedicatedAuditlogSecretReference
+	}
+	return SharedAuditlogSecretReference
 }
 
 type Configuration map[providerType]map[region]AuditLogData

--- a/pkg/gardener/shoot/extender/auditlogs/extender.go
+++ b/pkg/gardener/shoot/extender/auditlogs/extender.go
@@ -28,7 +28,7 @@ func NewAuditlogExtender(policyConfigMapName string, data AuditLogData) Extend {
 	return func(rt imv1.Runtime, shoot *gardener.Shoot) error {
 		policyConfigMapName := fixPolicyConfigMapName(rt.Annotations, policyConfigMapName)
 		for _, f := range []operation{
-			oSetSecret(data.SecretName),
+			oSetSecret(data.SecretReferenceName(), data.SecretName),
 			oSetPolicyConfigmap(policyConfigMapName),
 		} {
 			if err := f(shoot); err != nil {

--- a/pkg/gardener/shoot/extender/auditlogs/set_secret.go
+++ b/pkg/gardener/shoot/extender/auditlogs/set_secret.go
@@ -7,12 +7,19 @@ import (
 	v1 "k8s.io/api/autoscaling/v1"
 )
 
-const auditlogSecretReference = "auditlog-credentials"
-
-func oSetSecret(secretName string) operation {
+func oSetSecret(referenceName, secretName string) operation {
 	return func(s *gardener.Shoot) error {
+		otherReferenceName := SharedAuditlogSecretReference
+		if referenceName == SharedAuditlogSecretReference {
+			otherReferenceName = DedicatedAuditlogSecretReference
+		}
+
+		s.Spec.Resources = slices.DeleteFunc(s.Spec.Resources, func(r gardener.NamedResourceReference) bool {
+			return r.Name == otherReferenceName
+		})
+
 		resource := gardener.NamedResourceReference{
-			Name: auditlogSecretReference,
+			Name: referenceName,
 			ResourceRef: v1.CrossVersionObjectReference{
 				Name:       secretName,
 				Kind:       "Secret",
@@ -20,7 +27,7 @@ func oSetSecret(secretName string) operation {
 			},
 		}
 		index := slices.IndexFunc(s.Spec.Resources, func(r gardener.NamedResourceReference) bool {
-			return r.Name == auditlogSecretReference
+			return r.Name == referenceName
 		})
 
 		if index == -1 {

--- a/pkg/gardener/shoot/extender/auditlogs/set_secret_test.go
+++ b/pkg/gardener/shoot/extender/auditlogs/set_secret_test.go
@@ -11,31 +11,33 @@ import (
 
 func Test_oSetSecret(t *testing.T) {
 	for _, testCase := range []struct {
-		shoot      gardener.Shoot
-		secretName string
+		shoot         gardener.Shoot
+		referenceName string
+		secretName    string
 	}{
 		{
-			shoot:      gardener.Shoot{},
-			secretName: "test-secret",
+			shoot:         gardener.Shoot{},
+			referenceName: SharedAuditlogSecretReference,
+			secretName:    "test-secret",
 		},
 	} {
 		// given
-		operate := oSetSecret(testCase.secretName)
+		operate := oSetSecret(testCase.referenceName, testCase.secretName)
 
 		// when
 		err := operate(&testCase.shoot)
 
 		// then
 		require.NoError(t, err)
-		requireNoErrorAssertContainsSecretResource(t, testCase.secretName, testCase.shoot.Spec.Resources)
+		requireNoErrorAssertContainsSecretResource(t, testCase.referenceName, testCase.secretName, testCase.shoot.Spec.Resources)
 	}
 }
 
-func requireNoErrorAssertContainsSecretResource(t *testing.T, expected string, actual []gardener.NamedResourceReference) {
+func requireNoErrorAssertContainsSecretResource(t *testing.T, expectedRefName, expectedSecretName string, actual []gardener.NamedResourceReference) {
 	index := slices.IndexFunc(actual, func(r gardener.NamedResourceReference) bool {
-		return r.Name == auditlogSecretReference
+		return r.Name == expectedRefName
 	})
-	require.NotEqual(t, -1, index, "'%s' NamedResourceReference not found", auditlogSecretReference)
-	assert.Equal(t, auditlogSecretReference, actual[index].Name)
-	assert.Equal(t, expected, actual[index].ResourceRef.Name)
+	require.NotEqual(t, -1, index, "'%s' NamedResourceReference not found", expectedRefName)
+	assert.Equal(t, expectedRefName, actual[index].Name)
+	assert.Equal(t, expectedSecretName, actual[index].ResourceRef.Name)
 }

--- a/pkg/gardener/shoot/extender/extensions/auditlog.go
+++ b/pkg/gardener/shoot/extender/extensions/auditlog.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	AuditlogExtensionType = "shoot-auditlog-service"
-	auditlogReferenceName = "auditlog-credentials"
 )
 
 type AuditlogExtensionConfig struct {
@@ -36,7 +35,7 @@ func NewAuditLogExtension(d auditlogs.AuditLogData) (*gardener.Extension, error)
 		Type:                "standard",
 		TenantID:            d.TenantID,
 		ServiceURL:          d.ServiceURL,
-		SecretReferenceName: auditlogReferenceName,
+		SecretReferenceName: d.SecretReferenceName(),
 	}
 	var buffer bytes.Buffer
 	if err := json.NewEncoder(&buffer).Encode(&cfg); err != nil {

--- a/pkg/gardener/shoot/extender/extensions/extensions_extender_test.go
+++ b/pkg/gardener/shoot/extender/extensions/extensions_extender_test.go
@@ -751,7 +751,7 @@ func verifyAuditLogExtension(t *testing.T, ext gardener.Extension, expected audi
 	assert.Equal(t, "standard", auditlogConfig.Type)
 	assert.Equal(t, expected.TenantID, auditlogConfig.TenantID)
 	assert.Equal(t, expected.ServiceURL, auditlogConfig.ServiceURL)
-	assert.Equal(t, auditlogReferenceName, auditlogConfig.SecretReferenceName)
+	assert.Equal(t, expected.SecretReferenceName(), auditlogConfig.SecretReferenceName)
 	assert.Equal(t, "service.auditlog.extensions.gardener.cloud/v1alpha1", auditlogConfig.APIVersion)
 	assert.Equal(t, "AuditlogConfig", auditlogConfig.Kind)
 }


### PR DESCRIPTION
# Fix Dedicated Auditlog Patch: Correct Secret Reference Name Handling

### Bug Fix

🐛 This PR fixes several issues with dedicated audit log configuration for Gardener shoots. The core problem was that the `toExtenderAuditLogData` function did not propagate the `dedicated` flag, causing incorrect secret reference names to be used. Additionally, when migrating from shared to dedicated audit logging, the stale `auditlog-credentials` resource reference was not being removed from `shoot.spec.resources`.

### Changes

* `pkg/gardener/shoot/extender/auditlogs/auditlogs_configuration.go`: Introduced `SharedAuditlogSecretReference` and `DedicatedAuditlogSecretReference` constants. Added a `Dedicated bool` field to `AuditLogData` and a `SecretReferenceName()` helper method that returns the correct reference name based on the mode.

* `pkg/gardener/shoot/extender/auditlogs/set_secret.go`: Updated `oSetSecret` to accept a `referenceName` parameter. The function now removes the opposite-mode reference (shared or dedicated) from `shoot.spec.resources` before upserting the correct one, preventing stale references.

* `pkg/gardener/shoot/extender/auditlogs/extender.go`: Updated `NewAuditlogExtender` to pass `data.SecretReferenceName()` to `oSetSecret`, ensuring the correct reference name is used.

* `pkg/gardener/shoot/extender/extensions/auditlog.go`: Removed the hardcoded `auditlogReferenceName` constant and replaced it with a call to `d.SecretReferenceName()` so the extension config reflects the correct mode.

* `internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go`: Updated `toExtenderAuditLogData` to accept a `dedicated bool` parameter and populate the `Dedicated` field. All call sites updated to pass `true` for dedicated and `false` for shared flows.

* `internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers.go`: Replaced local constant `dedicatedAuditlogSecretReference` with the shared constants from the `auditlogs` package. The `upsertAuditLogSecretReference` function now removes the stale `auditlog-credentials` reference when migrating to dedicated.

* `pkg/gardener/shoot/extender/auditlogs/set_secret_test.go`: Updated tests to match the new `oSetSecret` signature with both `referenceName` and `secretName`.

* `pkg/gardener/shoot/converter_test.go`: Added a new test case verifying that a patch on a shoot already using dedicated audit logging does not revert to the shared secret reference name and that stale shared references are cleaned up.

* `internal/controller/runtime/fsm/runtime_fsm_migrate_dedicated_auditlog_helpers_test.go`: Added a new test verifying that the stale `auditlog-credentials` resource entry is removed when migrating to dedicated audit logging.

* `pkg/gardener/shoot/extender/extensions/extensions_extender_test.go`: Updated assertion to use `expected.SecretReferenceName()` instead of the removed hardcoded constant.

* `docs/adr/006-enable-dedicated-auditlog-for-existing-runtimes-implementation.md`: Updated the ADR to reflect the corrected `toExtenderAuditLogData` signature, the updated `oSetSecret` behavior, and the corrected scenario coverage table.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `db3ab2f0-91a3-11f1-83b5-540b1658db92`
</details>

Resolves #1559 